### PR TITLE
Update Event to compact JSON field names to match commit 3a5642b from `keripy`

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -72,22 +72,22 @@ var (
 )
 
 type Event struct {
-	Version                       string        `json:"vs"`
-	Prefix                        string        `json:"pre,omitempty"`
-	Sequence                      string        `json:"sn"`
-	EventType                     string        `json:"ilk"`
-	Digest                        string        `json:"dig,omitempty"`
-	SigningThreshold              string        `json:"sith,omitempty"`
-	Keys                          []string      `json:"keys,omitempty"`
-	Next                          string        `json:"nxt,omitempty"`
-	AccountableDuplicityThreshold string        `json:"toad,omitempty"`
-	Witnesses                     []string      `json:"wits,omitempty"`
-	Add                           []string      `json:"adds,omitempty"`
-	Cut                           []string      `json:"cuts,omitempty"`
-	Config                        []interface{} `json:"cnfg,omitempty"`
+	Version                       string        `json:"v"`
+	Prefix                        string        `json:"i,omitempty"`
+	Sequence                      string        `json:"s"`
+	EventType                     string        `json:"t"`
+	Digest                        string        `json:"p,omitempty"`
+	SigningThreshold              string        `json:"kt,omitempty"`
+	Keys                          []string      `json:"k,omitempty"`
+	Next                          string        `json:"n,omitempty"`
+	AccountableDuplicityThreshold string        `json:"wt,omitempty"`
+	Witnesses                     []string      `json:"w,omitempty"`
+	Add                           []string      `json:"wa,omitempty"`
+	Cut                           []string      `json:"wr,omitempty"`
+	Config                        []interface{} `json:"c,omitempty"`
 	Permissions                   []interface{} `json:"perm,omitempty"`
-	Data                          []Seal        `json:"data,omitempty"`
-	Seal                          []Seal        `json:"seal,omitempty"`
+	Data                          []Seal        `json:"a,omitempty"`
+	Seal                          []Seal        `json:"da,omitempty"`
 }
 
 // ILK returns the ILK iota value for the event
@@ -118,9 +118,9 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 
 		return json.Marshal(&struct {
 			*EventAlias
-			Cut  []string `json:"cuts"`
-			Add  []string `json:"adds"`
-			Data []Seal   `json:"data"`
+			Cut  []string `json:"wr"`
+			Add  []string `json:"wa"`
+			Data []Seal   `json:"a"`
 		}{
 			EventAlias: (*EventAlias)(e),
 			Cut:        e.Cut,
@@ -135,7 +135,7 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 		}
 		return json.Marshal(&struct {
 			*EventAlias
-			Data []Seal `json:"data"`
+			Data []Seal `json:"a"`
 		}{
 			EventAlias: (*EventAlias)(e),
 			Data:       e.Data,
@@ -152,8 +152,8 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 
 		return json.Marshal(&struct {
 			*EventAlias
-			Witnesses []string      `json:"wits"`
-			Config    []interface{} `json:"cnfg"`
+			Witnesses []string      `json:"w"`
+			Config    []interface{} `json:"c"`
 		}{
 			EventAlias: (*EventAlias)(e),
 			Witnesses:  e.Witnesses,

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -57,7 +57,7 @@ func TestSerialize(t *testing.T) {
 	assert := assert.New(t)
 
 	//JSON
-	expected := []byte(`{"vs":"KERI10JSON0000fb_","pre":"ETT9n-TCGn8XfkGkcNeNmZgdZSwHPLyDsojFXotBXdSo","sn":"0","ilk":"icp","sith":"1","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"nxt":"EGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_4","toad":"0","wits":[],"cnfg":[]}`)
+	expected := []byte(`{"v":"KERI10JSON0000fb_","i":"ETT9n-TCGn8XfkGkcNeNmZgdZSwHPLyDsojFXotBXdSo","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_4","wt":"0","w":[],"c":[]}`)
 
 	e := &Event{
 		Version:                       "KERI10JSON0000fb_",
@@ -86,9 +86,9 @@ func TestDigest(t *testing.T) {
 	assert := assert.New(t)
 
 	//JSON
-	data := []byte(`{"vs":"KERI10JSON0000fb_","pre":"ETT9n-TCGn8XfkGkcNeNmZgdZSwHPLyDsojFXotBXdSo","sn":"0","ilk":"icp","sith":"1","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"nxt":"EGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_4","toad":"0","wits":[],"cnfg":[]}`)
-	expectedString := "EixO2SBNow3tYDfYX6NRt1O9ZSMx2IsBeWkh8YJRp5VI"
-	expectedBytes := []byte{139, 19, 182, 72, 19, 104, 195, 123, 88, 13, 246, 23, 232, 212, 109, 212, 239, 89, 72, 204, 118, 34, 192, 94, 90, 72, 124, 96, 148, 105, 229, 82}
+	data := []byte(`{"v":"KERI10JSON0000fb_","i":"ETT9n-TCGn8XfkGkcNeNmZgdZSwHPLyDsojFXotBXdSo","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_4","wt":"0","w":[],"c":[]}`)
+	expectedString := "ErgY910xsF3NSLGH4Yl6O9oEkdxj0FOujnHTD8W5V_AI"
+	expectedBytes := []byte{174, 6, 61, 215, 76, 108, 23, 115, 82, 44, 97, 248, 98, 94, 142, 246, 129, 36, 119, 24, 244, 20, 235, 163, 156, 116, 195, 241, 110, 85, 252, 2}
 
 	digestBytes, err := Digest(data, derivation.Blake3256)
 	assert.Nil(err)

--- a/pkg/log/main.go
+++ b/pkg/log/main.go
@@ -78,7 +78,7 @@ func (l *Log) Apply(e *event.Event) error {
 
 	incomingDerivation, err := derivation.FromPrefix(e.Digest)
 	if err != nil {
-		return fmt.Errorf("unable to determin digest derivation (%s)", err)
+		return fmt.Errorf("unable to determine digest derivation (%s)", err)
 	}
 
 	cSerialized, err := current.Serialize()

--- a/pkg/log/main_test.go
+++ b/pkg/log/main_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/decentralized-identity/kerigo/pkg/derivation"
 	"github.com/decentralized-identity/kerigo/pkg/event"
 	"github.com/decentralized-identity/kerigo/pkg/prefix"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestOrder(t *testing.T) {
@@ -46,7 +47,7 @@ func TestApply(t *testing.T) {
 	assert := assert.New(t)
 
 	// Pre-defined inception json
-	inceptionBytes := []byte(`{"vs":"KERI10JSON0000cf_","pre":"Bh8On2eI1L-5OhKPLgnMh80ovcP8sV6E7Lcg3FDy-TbI","sn":"0","ilk":"icp","sith":"1","keys":["Bh8On2eI1L-5OhKPLgnMh80ovcP8sV6E7Lcg3FDy-TbI"],"nxt":"","toad":"0","wits":[],"cnfg":[]}`)
+	inceptionBytes := []byte(`{"v":"KERI10JSON0000cf_","i":"Bh8On2eI1L-5OhKPLgnMh80ovcP8sV6E7Lcg3FDy-TbI","s":"0","t":"icp","kt":"1","k":["Bh8On2eI1L-5OhKPLgnMh80ovcP8sV6E7Lcg3FDy-TbI"],"n":"","wt":"0","w":[],"c":[]}`)
 	icp := &event.Event{}
 	err := json.Unmarshal(inceptionBytes, icp)
 	assert.Nil(err)
@@ -105,8 +106,8 @@ func TestVerify(t *testing.T) {
 
 	l := Log{}
 
-	incept := []byte(`{"vs":"KERI10JSON0000fb_","pre":"ETT9n-TCGn8XfkGkcNeNmZgdZSwHPLyDsojFXotBXdSo","sn":"0","ilk":"icp","sith":"1","keys":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"nxt":"EGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_4","toad":"0","wits":[],"cnfg":[]}`)
-	inceptSig := []byte(`-AABAAtf0OqrkGmK3vdMcS5E3mLxeFh14SbvCNjZnZrxAazgYTemZc1S-Pr0ge9IQuHesmh8cJncRkef1PgxFavDKqDQ`)
+	incept := []byte(`{"v":"KERI10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}`)
+	inceptSig := []byte(`-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
 
 	msg := &event.Message{Event: &event.Event{}}
 	err := json.Unmarshal(incept, msg.Event)
@@ -125,14 +126,14 @@ func TestVerify(t *testing.T) {
 	err = l.Apply(msg.Event)
 	assert.Nil(err)
 
-	ixn := []byte(`{"vs":"KERI10JSON0000a3_","pre":"ETT9n-TCGn8XfkGkcNeNmZgdZSwHPLyDsojFXotBXdSo","sn":"1","ilk":"ixn","dig":"EixO2SBNow3tYDfYX6NRt1O9ZSMx2IsBeWkh8YJRp5VI","data":[]}`)
-	ixnSig := []byte(`-AABAAaptFFViQVJs2Rj0zuoOId1qy0B0piJmN7uxxD4N1wJapWXdxSZq-Z3Le6XmbPaMGf7xdfrh7IHi15h-9b7mKBQ`)
+	rot := []byte(`{"v":"KERI10JSON000122_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"1","t":"rot","p":"E9ZTKOhr-lqB7jbBMBpUIdMpfWvEswoMoc5UrwCRcTSc","kt":"1","k":["DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI"],"n":"E-dapdcC6XR1KWmWDsNl4J_OxcGxNZw1Xd95JH5a34fI","wt":"0","wr":[],"wa":[],"a":[]}`)
+	rotSig := []byte(`-AABAA91xjNugSykLy0_IZsvkUxkVnZVlNqqhhZT5_VT9wK0pccNrD6i_3h_lTK5ZmXr0wsN6zn-4KMw3ZtYQ2bjbuDQ`)
 
 	msg = &event.Message{Event: &event.Event{}}
-	err = json.Unmarshal(ixn, msg.Event)
+	err = json.Unmarshal(rot, msg.Event)
 	assert.Nil(err)
 
-	sigs, extra, err = derivation.ParseAttachedSignatures(ixnSig)
+	sigs, extra, err = derivation.ParseAttachedSignatures(rotSig)
 	assert.Empty(extra)
 	assert.Nil(err)
 	assert.Len(sigs, 1)
@@ -143,14 +144,14 @@ func TestVerify(t *testing.T) {
 	err = l.Apply(msg.Event)
 	assert.Nil(err)
 
-	rot := []byte(`{"vs":"KERI10JSON00013a_","pre":"ETT9n-TCGn8XfkGkcNeNmZgdZSwHPLyDsojFXotBXdSo","sn":"2","ilk":"rot","dig":"EOphiyHf3RGC_gP0_lj402J7-4ux6UpKvDnX8sssu2pc","sith":"1","keys":["DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI"],"nxt":"EoWDoTGQZ6lJ19LsaV4g42k5gccsB_-ttYHOft6kuYZk","toad":"0","cuts":[],"adds":[],"data":[]}`)
-	rotSig := []byte(`-AABAAtuSAbqbOMXTnphZx_c1mH875OO8cQi6zeeTXgDz2LSsnJeOJI2Ov7BF6Sq7YuAXYfkWIOWGdHuFzAFAcx0udBw`)
+	ixn := []byte(`{"v":"KERI10JSON000098_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"2","t":"ixn","p":"ELWbb2Oun3FTpWZqHYmeefM5B-11nZQBsxPfufyjJHy4","a":[]}`)
+	ixnSig := []byte(`-AABAAqxzoxk4rltuP41tB8wEpHFC4Yd1TzhOGfuhlylbDFAm73jB2emdvaLjUP6FrHxiPqS2CcbAWaVNsmii80KJEBw`)
 
 	msg = &event.Message{Event: &event.Event{}}
-	err = json.Unmarshal(rot, msg.Event)
+	err = json.Unmarshal(ixn, msg.Event)
 	assert.Nil(err)
 
-	sigs, extra, err = derivation.ParseAttachedSignatures(rotSig)
+	sigs, extra, err = derivation.ParseAttachedSignatures(ixnSig)
 	assert.Empty(extra)
 	assert.Nil(err)
 	assert.Len(sigs, 1)


### PR DESCRIPTION
In an attempt to replicate the Bob/Sam/Eve demo from `keripy` in Go I discovered the mismatched JSON field names.

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>