### PR TITLE
Adds basic GitHub Actions support.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,26 @@
+name: Build
+on: [ push, pull_request ]
+
+jobs:
+  test:
+    name: Unit Test
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        go-version: [1.13, 1.14, 1.15]
+    steps:
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Test
+      run: make test
+
+    - name: Upload coverage to Codecov
+      timeout-minutes: 5
+      run: curl -s https://codecov.io/bash | bash

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: all
+all: test
+
+.PHONY: test
+test:
+	@scripts/check_unit.sh
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # KERIGO
 Go implementation of KERI  (Key Event Receipt Infrastructure)
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/decentralized-identity/kerigo/master/LICENSE)
+![Go Version](https://img.shields.io/github/go-mod/go-version/decentralized-identity/kerigo)
+![Build](https://github.com/decentralized-identity/kerigo/workflows/Build/badge.svg)
+[![codecov](https://codecov.io/gh/decentralized-identity/kerigo/branch/master/graph/badge.svg)](https://codecov.io/gh/decentralized-identity/kerigo)
+[![Go Report Card](https://goreportcard.com/badge/github.com/decentralized-identity/kerigo)](https://goreportcard.com/report/github.com/decentralized-identity/kerigo)
 # Introduction
 
 KERIGO is an open source go implementation of the [ Key Event Receipt Infrastructure (KERI) ](https://github.com/decentralized-identity/keri), a system designed to provide a secure identifier-based trust spanning layer for any stack. [The current version of the KERI paper can be found here](https://github.com/SmithSamuelM/Papers/blob/master/whitepapers/KERI_WP_2.x.web.pdf).

--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+echo -n > coverage.out
+echo "Running $0"
+
+GO_TEST_CMD="go test"
+
+PKGS=$(go list github.com/decentralized-identity/kerigo/... 2> /dev/null | grep -v vendor)
+$GO_TEST_CMD $PKGS -count=1 -race -coverprofile=profile.out -covermode=atomic -timeout=10m
+if [ -f profile.out ]; then
+  cat profile.out >>coverage.out
+  rm profile.out
+fi


### PR DESCRIPTION
Tests run on pushes and pull requests.
Added a Makefile and `test` command to run all tests in the package for use in GitHub Action build.yml.

Adds some badges for fun :)

Code Coverage can be enabled by one of the maintainers visiting:

https://codecov.io/gh/decentralized-identity/kerigo

and adding the CODECOV_TOKEN to GitHub -> Settings -> Secrets