### PR TITLE
Basic streaming inbound event message transport.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/google/tink/go v1.5.0
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/sys v0.0.0-20201101102859-da207088b7d1 // indirect

--- a/pkg/derivation/main_test.go
+++ b/pkg/derivation/main_test.go
@@ -1,6 +1,7 @@
 package derivation
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/base64"
 	"testing"
@@ -309,17 +310,15 @@ func TestParseAttachedSignatures(t *testing.T) {
 	assert := assert.New(t)
 	sigString := []byte("-AABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 
-	ders, extra, err := ParseAttachedSignatures(sigString)
+	ders, err := ParseAttachedSignatures(bytes.NewBuffer(sigString))
 	assert.Nil(err)
-	assert.Empty(extra)
 	if assert.Len(ders, 1) {
 		assert.Equal(uint16(0), ders[0].KeyIndex)
 	}
 
 	sigString = []byte("-AACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
-	ders, extra, err = ParseAttachedSignatures(sigString)
+	ders, err = ParseAttachedSignatures(bytes.NewBuffer(sigString))
 	assert.Nil(err)
-	assert.Empty(extra)
 	if assert.Len(ders, 2) {
 		assert.Equal(uint16(0), ders[0].KeyIndex)
 		assert.Equal(uint16(1), ders[1].KeyIndex)
@@ -327,20 +326,17 @@ func TestParseAttachedSignatures(t *testing.T) {
 
 	// Correctly return extra bytes
 	sigString = []byte("-AACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsome extra data at the end")
-	ders, extra, err = ParseAttachedSignatures(sigString)
+	ders, err = ParseAttachedSignatures(bytes.NewBuffer(sigString))
 	assert.Nil(err)
-	if assert.NotEmpty(extra) {
-		assert.Equal("some extra data at the end", string(extra))
-	}
 	assert.Len(ders, 2)
 
 	// Invalid derivation code for 3rd sig
 	sigString = []byte("-AADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsome extra data at the end")
-	_, _, err = ParseAttachedSignatures(sigString)
+	ders, err = ParseAttachedSignatures(bytes.NewBuffer(sigString))
 	assert.NotNil(err)
 
 	// Valid derivation for 3 sig, but invalid data length
 	sigString = []byte("-AADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAA")
-	_, _, err = ParseAttachedSignatures(sigString)
+	ders, err = ParseAttachedSignatures(bytes.NewBuffer(sigString))
 	assert.NotNil(err)
 }

--- a/pkg/derivation/sig-counter.go
+++ b/pkg/derivation/sig-counter.go
@@ -1,0 +1,63 @@
+package derivation
+
+import (
+	"fmt"
+)
+
+const (
+	SigCountCodeBase64 = "-A"
+	SigCountCodeBase2  = "-B"
+
+	SigCountLen = 2
+)
+
+var (
+	MaxPad = []string{"AAAAAAAAAA"}
+)
+
+type SigCountOpt func(*SigCounter) error
+
+type SigCounter struct {
+	code   string
+	count  uint16
+	length int
+}
+
+func NewSigCounter(opts ...SigCountOpt) (*SigCounter, error) {
+	s := &SigCounter{
+		code:  SigCountCodeBase64,
+		count: 1,
+	}
+
+	for _, o := range opts {
+		err := o(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return s, nil
+}
+
+func (r *SigCounter) String() (string, error) {
+	b64, err := IndexToBase64(r.count)
+	if err != nil {
+		return "", fmt.Errorf("unable to base64 encode signature count: %v", err)
+	}
+	pad := SigCountLen - len(b64)
+	return fmt.Sprintf("%s%.*s%s", r.code, pad, "A", b64), nil
+}
+
+func WithCount(count int) SigCountOpt {
+	return func(s *SigCounter) error {
+		s.count = uint16(count)
+		return nil
+	}
+}
+
+func WithSigCntCode(code string) SigCountOpt {
+	return func(s *SigCounter) error {
+		s.code = code
+		return nil
+	}
+}

--- a/pkg/derivation/sig-counter_test.go
+++ b/pkg/derivation/sig-counter_test.go
@@ -1,0 +1,67 @@
+package derivation
+
+import (
+	"testing"
+)
+
+func TestSigCounter_String(t *testing.T) {
+	type fields struct {
+		code   string
+		count  uint16
+		length int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "test 1",
+			fields:  fields{code: SigCountCodeBase64, count: 1, length: 2},
+			want:    "-AAB",
+			wantErr: false,
+		},
+		{
+			name:    "test 2",
+			fields:  fields{code: SigCountCodeBase64, count: 2, length: 2},
+			want:    "-AAC",
+			wantErr: false,
+		},
+		{
+			name:    "test 3",
+			fields:  fields{code: SigCountCodeBase64, count: 3, length: 2},
+			want:    "-AAD",
+			wantErr: false,
+		},
+		{
+			name:    "test 256",
+			fields:  fields{code: SigCountCodeBase64, count: 256, length: 2},
+			want:    "-AEA",
+			wantErr: false,
+		},
+		{
+			name:    "test 5000",
+			fields:  fields{code: SigCountCodeBase64, count: 5000, length: 2},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &SigCounter{
+				code:   tt.fields.code,
+				count:  tt.fields.count,
+				length: tt.fields.length,
+			}
+			got, err := r.String()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("String() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("String() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -2,11 +2,11 @@ package event
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 
 	"github.com/decentralized-identity/kerigo/pkg/derivation"
 	"github.com/decentralized-identity/kerigo/pkg/prefix"
@@ -80,6 +80,12 @@ var (
 		CBOR:  "CBOR",
 		MSGPK: "MSGPK",
 		EDS:   "ExtractedDataSet",
+	}
+
+	formatValue = map[string]FORMAT{
+		"JSON":  JSON,
+		"CBOR":  CBOR,
+		"MSGPK": MSGPK,
 	}
 )
 
@@ -290,6 +296,15 @@ func FormatFromVersion(vs string) (FORMAT, error) {
 	return -1, errors.New("unable to determin format from version string")
 }
 
+func Format(f string) (FORMAT, error) {
+	out, ok := formatValue[f]
+	if !ok {
+		return -1, errors.New("unrecognized format")
+	}
+
+	return out, nil
+}
+
 // Serialize the provided event to the format specifeid
 func Serialize(e *Event, to FORMAT) ([]byte, error) {
 	switch to {
@@ -297,6 +312,24 @@ func Serialize(e *Event, to FORMAT) ([]byte, error) {
 		return json.Marshal(e)
 	case EDS:
 		return e.extractDataSet()
+	case CBOR, MSGPK:
+		// unimplemented
+		// TODO: implement!
+		return nil, errors.New("unimplemented")
+	}
+
+	return nil, errors.New("unrecognized format")
+}
+
+func Deserialize(data []byte, from FORMAT) (*Event, error) {
+	switch from {
+	case JSON:
+		evt := &Event{}
+		err := json.Unmarshal(data, evt)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to unmarshal event from JSON")
+		}
+		return evt, nil
 	case CBOR, MSGPK:
 		// unimplemented
 		// TODO: implement!

--- a/pkg/event/message.go
+++ b/pkg/event/message.go
@@ -15,7 +15,17 @@ func (m Message) Serialize() ([]byte, error) {
 		return nil, err
 	}
 
-	//TODO: correct attached signature count code
+	sc, err := derivation.NewSigCounter(derivation.WithCount(len(m.Signatures)))
+	if err != nil {
+		return nil, err
+	}
+
+	cntCode, err := sc.String()
+	if err != nil {
+		return nil, err
+	}
+
+	evt = append(evt, cntCode...)
 	for _, sig := range m.Signatures {
 		evt = append(evt, sig.AsPrefix()...)
 	}

--- a/pkg/io/inbound.go
+++ b/pkg/io/inbound.go
@@ -1,0 +1,13 @@
+package io
+
+import (
+	"github.com/decentralized-identity/kerigo/pkg/event"
+)
+
+type InboundTransport interface {
+	// Start starts the inbound transport.  It returns a channel of event.Messages or an error
+	Start() (<-chan *event.Message, error)
+
+	// Stop halts the inbound transport
+	Stop()
+}

--- a/pkg/io/stream/inbound.go
+++ b/pkg/io/stream/inbound.go
@@ -1,0 +1,160 @@
+package stream
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+	"github.com/decentralized-identity/kerigo/pkg/event"
+)
+
+const (
+	FullVerSize = 17
+
+	MinSniffSize = 12 + FullVerSize
+
+	Verex = `KERI(?P<major>[0-9a-f])(?P<minor>[0-9a-f])(?P<kind>[A-Z]{4})(?P<size>[0-9a-f]{6})_`
+
+	MessageBufferSize = 5
+)
+
+var (
+	Rever = regexp.MustCompile(Verex)
+)
+
+type Inbound struct {
+	addr string
+
+	connLock sync.Mutex
+	conns    []net.Conn
+
+	ch chan *event.Message
+}
+
+func NewStreamInbound(addr string) (*Inbound, error) {
+	return &Inbound{
+		addr: addr,
+		ch:   make(chan *event.Message, MessageBufferSize),
+	}, nil
+}
+
+func (r *Inbound) Start() (<-chan *event.Message, error) {
+	ln, err := net.Listen("tcp", r.addr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to listen on %s", r.addr)
+	}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				log.Printf("unexpected error accepting connection: %v", err)
+				continue
+			}
+
+			r.addConnection(conn)
+			go func() {
+				err := r.handleConnection(conn)
+				r.remoteConnection(conn)
+				log.Printf("connection closed with err: %v\n", err)
+			}()
+		}
+	}()
+
+	return r.ch, nil
+}
+
+func (r *Inbound) Stop() {
+	r.connLock.Lock()
+	defer r.connLock.Unlock()
+
+	for _, conn := range r.conns {
+		_ = conn.Close()
+	}
+
+	close(r.ch)
+}
+
+func (r *Inbound) handleConnection(conn io.Reader) error {
+	c := bufio.NewReader(conn)
+
+	for {
+		// read a min sized buffer which contains the message length
+		h, err := c.Peek(MinSniffSize)
+		if err != nil {
+			return fmt.Errorf("short peek: (%v)", err)
+		}
+
+		submatches := Rever.FindStringSubmatch(string(h))
+		if len(submatches) != 5 {
+			return errors.New("invalid version string")
+		}
+
+		ser := strings.TrimSpace(submatches[3])
+		hex := submatches[4]
+
+		size, err := strconv.ParseInt(hex, 16, 64)
+		if err != nil {
+			return errors.Wrap(err, "invalid message size hex")
+		}
+
+		f, err := event.Format(ser)
+		if err != nil {
+			return err
+		}
+
+		buff := make([]byte, size)
+		_, err = io.ReadFull(c, buff)
+		if err != nil {
+			return err
+		}
+
+		msg := &event.Message{}
+		msg.Event, err = event.Deserialize(buff, f)
+		if err != nil {
+			return fmt.Errorf("unable to unmarshal event: (%v)", err)
+		}
+
+		sigs, err := derivation.ParseAttachedSignatures(c)
+		if err != nil {
+			return fmt.Errorf("error parsing sigs: %v", err)
+		}
+
+		msg.Signatures = sigs
+
+		r.ch <- msg
+	}
+}
+
+func (r *Inbound) addConnection(conn net.Conn) {
+	r.connLock.Lock()
+	defer r.connLock.Unlock()
+
+	r.conns = append(r.conns, conn)
+}
+
+func (r *Inbound) remoteConnection(conn net.Conn) {
+	r.connLock.Lock()
+	defer r.connLock.Unlock()
+
+	idx := -1
+	for i, c := range r.conns {
+		if c == conn {
+			idx = i
+			break
+		}
+	}
+
+	if idx != -1 {
+		r.conns = append(r.conns[:idx], r.conns[idx+1:]...)
+	}
+}

--- a/pkg/io/stream/inbound_test.go
+++ b/pkg/io/stream/inbound_test.go
@@ -1,0 +1,139 @@
+package stream
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingleMessage(t *testing.T) {
+	addr := ":5601"
+	d := []byte(`{"v":"KERI10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
+
+	target, err := NewStreamInbound(addr)
+	assert.NoError(t, err)
+
+	ch, err := target.Start()
+	assert.NoError(t, err)
+
+	sendMsg(t, addr, d)
+
+	msg := <-ch
+	assert.Equal(t, "ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY", msg.Event.Prefix)
+	assert.Len(t, msg.Signatures, 1)
+	assert.Equal(t, "AAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg", msg.Signatures[0].AsPrefix())
+
+	target.Stop()
+}
+
+func TestMultipleMessages(t *testing.T) {
+	addr := ":5602"
+	d := []byte(`{"v":"KERI10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
+	d2 := []byte(`{"v":"KERI10JSON000122_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"1","t":"rot","p":"E9ZTKOhr-lqB7jbBMBpUIdMpfWvEswoMoc5UrwCRcTSc","kt":"1","k":["DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI"],"n":"E-dapdcC6XR1KWmWDsNl4J_OxcGxNZw1Xd95JH5a34fI","wt":"0","wr":[],"wa":[],"a":[]}-AABAA91xjNugSykLy0_IZsvkUxkVnZVlNqqhhZT5_VT9wK0pccNrD6i_3h_lTK5ZmXr0wsN6zn-4KMw3ZtYQ2bjbuDQ`)
+
+	target, err := NewStreamInbound(addr)
+	assert.NoError(t, err)
+
+	ch, err := target.Start()
+	assert.NoError(t, err)
+
+	sendMsg(t, addr, d, d2)
+
+	msg := <-ch
+	assert.Equal(t, "ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY", msg.Event.Prefix)
+	assert.Len(t, msg.Signatures, 1)
+	assert.Equal(t, "AAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg", msg.Signatures[0].AsPrefix())
+
+	msg = <-ch
+	assert.Equal(t, "E9ZTKOhr-lqB7jbBMBpUIdMpfWvEswoMoc5UrwCRcTSc", msg.Event.Digest)
+	assert.Len(t, msg.Signatures, 1)
+	assert.Equal(t, "AA91xjNugSykLy0_IZsvkUxkVnZVlNqqhhZT5_VT9wK0pccNrD6i_3h_lTK5ZmXr0wsN6zn-4KMw3ZtYQ2bjbuDQ", msg.Signatures[0].AsPrefix())
+
+	target.Stop()
+}
+
+func TestMultipleWrites(t *testing.T) {
+	addr := ":5603"
+	d := []byte(`{"v":"KERI`)
+	d2 := []byte(`10JSON000122_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"1","t":"rot","p":"E9ZTKOhr-lqB7jbBMBpUIdMpfWvEswoMoc5UrwCRcTSc","kt":"1","k":["DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI"],"n":"E-dapdcC6XR1KWmWDsNl4J_OxcGxNZw1Xd95JH5a34fI","wt":"0","wr":[],"wa":[],"a":[]}-AABAA91xjNugSykLy0_IZsvkUxkVnZVlNqqhhZT5_VT9wK0pccNrD6i_3h_lTK5ZmXr0wsN6zn-4KMw3ZtYQ2bjbuDQ`)
+
+	target, err := NewStreamInbound(addr)
+	assert.NoError(t, err)
+
+	ch, err := target.Start()
+	assert.NoError(t, err)
+
+	sendMsg(t, addr, d, d2)
+
+	msg := <-ch
+	assert.Equal(t, "E9ZTKOhr-lqB7jbBMBpUIdMpfWvEswoMoc5UrwCRcTSc", msg.Event.Digest)
+	assert.Len(t, msg.Signatures, 1)
+	assert.Equal(t, "AA91xjNugSykLy0_IZsvkUxkVnZVlNqqhhZT5_VT9wK0pccNrD6i_3h_lTK5ZmXr0wsN6zn-4KMw3ZtYQ2bjbuDQ", msg.Signatures[0].AsPrefix())
+
+	target.Stop()
+}
+
+func TestBadData(t *testing.T) {
+	t.Run("bad version string", func(t *testing.T) {
+		addr := ":5604"
+		d := []byte(`{"v":"KERL10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
+
+		target, err := NewStreamInbound(addr)
+		assert.NoError(t, err)
+
+		_, err = target.Start()
+		assert.NoError(t, err)
+
+		sendMsg(t, addr, d)
+	})
+	t.Run("bad format string", func(t *testing.T) {
+		addr := ":5605"
+		d := []byte(`{"v":"KERI10PROT0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
+
+		target, err := NewStreamInbound(addr)
+		assert.NoError(t, err)
+
+		_, err = target.Start()
+		assert.NoError(t, err)
+
+		sendMsg(t, addr, d)
+	})
+	t.Run("bad JSON", func(t *testing.T) {
+		addr := ":5606"
+		d := []byte(`{"v":"KERI10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY},"s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
+
+		target, err := NewStreamInbound(addr)
+		assert.NoError(t, err)
+
+		_, err = target.Start()
+		assert.NoError(t, err)
+
+		sendMsg(t, addr, d)
+	})
+	t.Run("bad signature", func(t *testing.T) {
+		addr := ":5607"
+		d := []byte(`{"v":"KERI10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-XYZBAA`)
+
+		target, err := NewStreamInbound(addr)
+		assert.NoError(t, err)
+
+		_, err = target.Start()
+		assert.NoError(t, err)
+
+		sendMsg(t, addr, d)
+	})
+}
+
+func sendMsg(t *testing.T, addr string, msgs ...[]byte) {
+	client, err := net.Dial("tcp", addr)
+	assert.NoError(t, err)
+
+	for _, msg := range msgs {
+		_, err = client.Write(msg)
+		assert.NoError(t, err)
+	}
+
+	err = client.Close()
+	assert.NoError(t, err)
+}

--- a/pkg/log/main_test.go
+++ b/pkg/log/main_test.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
@@ -65,8 +66,7 @@ func TestVerifyAndApply(t *testing.T) {
 	err := json.Unmarshal(incept, msg.Event)
 	assert.Nil(err)
 
-	sigs, extra, err := derivation.ParseAttachedSignatures(inceptSig)
-	assert.Empty(extra)
+	sigs, err := derivation.ParseAttachedSignatures(bytes.NewBuffer(inceptSig))
 	assert.Nil(err)
 	assert.Len(sigs, 1)
 
@@ -86,8 +86,7 @@ func TestVerifyAndApply(t *testing.T) {
 	err = json.Unmarshal(rot, msg.Event)
 	assert.Nil(err)
 
-	sigs, extra, err = derivation.ParseAttachedSignatures(rotSig)
-	assert.Empty(extra)
+	sigs, err = derivation.ParseAttachedSignatures(bytes.NewBuffer(rotSig))
 	assert.Nil(err)
 	assert.Len(sigs, 1)
 
@@ -134,8 +133,7 @@ func TestVerifyAndApply(t *testing.T) {
 	err = json.Unmarshal(ixn, msg.Event)
 	assert.Nil(err)
 
-	sigs, extra, err = derivation.ParseAttachedSignatures(ixnSig)
-	assert.Empty(extra)
+	sigs, err = derivation.ParseAttachedSignatures(bytes.NewBuffer(ixnSig))
 	assert.Nil(err)
 	assert.Len(sigs, 1)
 


### PR DESCRIPTION
This PR contains:

- A basic inbound transport to handle an unframed stream (TCP) of messages.
- A fix to message serialization to include the signature count prefix.

Closes #14

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>