### PR TITLE
MultiSig and Duplicitous Escrow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/decentralized-identity/kerigo
 go 1.13
 
 require (
+	github.com/aws/aws-sdk-go v1.35.7
 	github.com/google/tink/go v1.5.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go v1.35.7 h1:FHMhVhyc/9jljgFAcGkQDYjpC9btM0B8VfkLBfctdNE=
 github.com/aws/aws-sdk-go v1.35.7/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -130,6 +131,7 @@ github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvh
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -95,7 +95,7 @@ type Event struct {
 	Sequence                      string         `json:"s"`
 	EventType                     string         `json:"t"`
 	Digest                        string         `json:"p,omitempty"`
-	SigningThreshold              string         `json:"kt,omitempty"`
+	SigThreshold                  *SigThreshold  `json:"kt,omitempty"`
 	Keys                          []string       `json:"k,omitempty"`
 	Next                          string         `json:"n,omitempty"`
 	AccountableDuplicityThreshold string         `json:"wt,omitempty"`
@@ -212,16 +212,6 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 // hex sequence string
 func (e *Event) SequenceInt() int {
 	eInt, err := strconv.ParseInt(e.Sequence, 16, 64)
-	if err != nil {
-		return -1
-	}
-	return int(eInt)
-}
-
-// SigningThresholdInt returns an integer representation of
-// the hex signing threshold string
-func (e *Event) SigningThresholdInt() int {
-	eInt, err := strconv.ParseInt(e.SigningThreshold, 16, 64)
 	if err != nil {
 		return -1
 	}

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,7 +67,7 @@ func TestSerialize(t *testing.T) {
 		Prefix:                        "ETT9n-TCGn8XfkGkcNeNmZgdZSwHPLyDsojFXotBXdSo",
 		EventType:                     "icp",
 		Sequence:                      "0",
-		SigningThreshold:              "1",
+		SigThreshold:                  &SigThreshold{conditions: [][]*big.Rat{{big.NewRat(1, 1)}}},
 		AccountableDuplicityThreshold: "0",
 		Keys:                          []string{"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"},
 		Next:                          "EGAPkzNZMtX-QiVgbRbyAIZGoXvbGv9IPb0foWTZvI_4",
@@ -109,14 +110,4 @@ func TestSequenceInt(t *testing.T) {
 
 	e.Sequence = fmt.Sprintf("%x", 93840482)
 	assert.Equal(93840482, e.SequenceInt())
-}
-
-func TestSigningThresholdInt(t *testing.T) {
-	assert := assert.New(t)
-
-	e := Event{SigningThreshold: "0"}
-	assert.Equal(0, e.SigningThresholdInt())
-
-	e.SigningThreshold = fmt.Sprintf("%x", 93840482)
-	assert.Equal(93840482, e.SigningThresholdInt())
 }

--- a/pkg/event/sig-threshold.go
+++ b/pkg/event/sig-threshold.go
@@ -1,0 +1,217 @@
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strconv"
+
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+	"github.com/pkg/errors"
+)
+
+type SigThreshold struct {
+	conditions [][]*big.Rat
+}
+
+// MarshalJSON is used to correctly output the JSON since this field can
+// contain a single int, a list, or a list of lists
+func (s *SigThreshold) MarshalJSON() ([]byte, error) {
+	switch len(s.conditions) {
+	case 0:
+		return json.Marshal("0")
+	case 1:
+		if len(s.conditions[0]) == 1 {
+			return json.Marshal(s.conditions[0][0])
+		}
+		return json.Marshal(s.conditions[0])
+	}
+
+	return json.Marshal(s.conditions)
+}
+
+func (s *SigThreshold) UnmarshalJSON(in []byte) error {
+	// check the smiplest first - that the input is a simple string
+	if string(in[:1]) == `"` {
+		parsed := ""
+		err := json.Unmarshal(in, &parsed)
+		if err != nil {
+			return nil
+		}
+
+		tholdint, err := strconv.Atoi(parsed)
+		if err != nil {
+			return err
+		}
+
+		s.conditions = [][]*big.Rat{{big.NewRat(int64(tholdint), 1)}}
+		return nil
+	}
+
+	// it's either a list, or list of lists
+	tholds := []interface{}{}
+
+	err := json.Unmarshal(in, &tholds)
+	if err != nil {
+		return err
+	}
+
+	if len(tholds) == 0 {
+		s.conditions = [][]*big.Rat{}
+	} else {
+		// if the first item is a string, we will treat this as a weighted thresholed
+		if _, ok := tholds[0].(string); ok {
+			conditions := []string{}
+			for _, t := range tholds {
+				if ts, ok := t.(string); ok {
+					conditions = append(conditions, ts)
+				}
+			}
+
+			converted, err := parseConditions(conditions)
+			if err != nil {
+				return err
+			}
+
+			s.conditions = append(s.conditions, converted)
+		}
+
+		// if the first item is a slice, we will treat this as a multi-weighted
+		if _, ok := tholds[0].([]interface{}); ok {
+			for _, t := range tholds {
+				if ti, ok := t.([]interface{}); ok {
+					conditions := []string{}
+					for _, iface := range ti {
+						if ts, ok := iface.(string); ok {
+							conditions = append(conditions, ts)
+						}
+					}
+
+					converted, err := parseConditions(conditions)
+					if err != nil {
+						return err
+					}
+
+					s.conditions = append(s.conditions, converted)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func parseConditions(conditions []string) ([]*big.Rat, error) {
+	converted := []*big.Rat{}
+	for _, c := range conditions {
+		thold := new(big.Rat)
+
+		_, err := fmt.Sscan(c, thold)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse condition %s: %s", c, err)
+		}
+
+		if thold.Sign() == -1 {
+			return nil, errors.New("thresholds must be >= 0")
+		}
+
+		converted = append(converted, thold)
+	}
+
+	return converted, nil
+}
+
+// Satisfied takes the provided signature derivations and checkes each weighted
+// threshold
+func (s *SigThreshold) Satisfied(sigs []derivation.Derivation) bool {
+	if !s.Weighted() {
+		required := 0
+		if len(s.conditions) == 1 && len(s.conditions[0]) == 1 {
+			required = int(s.conditions[0][0].Num().Int64())
+		}
+		return len(sigs) >= required
+	}
+
+	for _, c := range s.conditions {
+		weight := big.NewRat(0, 1)
+		for _, s := range sigs {
+			// if our index is outside of the weighted list it doesn't count
+			if int(s.KeyIndex) >= len(c) {
+				continue
+			}
+
+			weight.Add(weight, c[int(s.KeyIndex)])
+		}
+
+		// if we failed to meet this weight, return false
+		if weight.Cmp(big.NewRat(1, 1)) == -1 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// returns true if this is a weighted threshold - i.e. there
+// is one or more lists of weights
+func (s *SigThreshold) Weighted() bool {
+	if len(s.conditions) < 1 || (len(s.conditions) == 1 && len(s.conditions[0]) == 1) {
+		return false
+	}
+
+	return true
+}
+
+// New returns a signing threshold requiring 'threshold' signatures
+func NewSigThreshold(threshold int64) (*SigThreshold, error) {
+	if threshold < 0 {
+		return nil, errors.New("threshold must be >= 0")
+	}
+
+	return &SigThreshold{[][]*big.Rat{{big.NewRat(threshold, 1)}}}, nil
+}
+
+// NewWeighted creates a new sighing threshold with a weighted multisig
+func NewWeighted(conditions ...string) (*SigThreshold, error) {
+	sum := new(big.Rat)
+
+	converted, err := parseConditions(conditions)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range converted {
+		sum.Add(sum, c)
+	}
+
+	if sum.Cmp(big.NewRat(1, 1)) == -1 {
+		return nil, errors.New("threshold not satifiable: sum of weights must be greather than 1")
+	}
+
+	return &SigThreshold{conditions: [][]*big.Rat{converted}}, nil
+}
+
+// NewMultiWeighted creates a new signing threshold with multiple
+// conditions
+func NewMultiWeighted(conditions ...[]string) (*SigThreshold, error) {
+	thresholds := [][]*big.Rat{}
+
+	for _, c := range conditions {
+		tot := new(big.Rat)
+		converted, err := parseConditions(c)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, frac := range converted {
+			tot = tot.Add(tot, frac)
+		}
+
+		if tot.Cmp(big.NewRat(1, 1)) == -1 {
+			return nil, fmt.Errorf("threshold not statisfiable (%s)", c)
+		}
+		thresholds = append(thresholds, converted)
+	}
+
+	return &SigThreshold{conditions: thresholds}, nil
+}

--- a/pkg/event/sig-threshold_test.go
+++ b/pkg/event/sig-threshold_test.go
@@ -1,0 +1,252 @@
+package event
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSigThreshold(t *testing.T) {
+	assert := assert.New(t)
+
+	st, err := NewSigThreshold(-1)
+	assert.Nil(st)
+	assert.Equal("threshold must be >= 0", err.Error())
+
+	st, err = NewSigThreshold(0)
+	assert.Nil(err)
+	assert.Equal([][]*big.Rat{{big.NewRat(0, 1)}}, st.conditions)
+
+	st, err = NewSigThreshold(1)
+	assert.Nil(err)
+	assert.Equal([][]*big.Rat{{big.NewRat(1, 1)}}, st.conditions)
+
+	st, err = NewSigThreshold(4)
+	assert.Nil(err)
+	assert.Equal([][]*big.Rat{{big.NewRat(4, 1)}}, st.conditions)
+
+	// This is a "simple" threshold, i.e. not weighted
+	assert.False(st.Weighted())
+
+	// thresholds must be > 1
+	st, err = NewWeighted()
+	assert.Nil(st)
+	assert.Equal("threshold not satifiable: sum of weights must be greather than 1", err.Error())
+
+	st, err = NewWeighted("1/2")
+	assert.Nil(st)
+	assert.Equal("threshold not satifiable: sum of weights must be greather than 1", err.Error())
+
+	st, err = NewWeighted("1/2", "1/4")
+	assert.Nil(st)
+	assert.Equal("threshold not satifiable: sum of weights must be greather than 1", err.Error())
+
+	// Invalid fractional representation
+	st, err = NewWeighted("asdf")
+	assert.Nil(st)
+	assert.Equal("unable to parse condition asdf: Rat.Scan: invalid syntax", err.Error())
+
+	// No negative weights
+	st, err = NewWeighted("1/4", "1/2", "-1/4")
+	assert.Nil(st)
+	assert.Equal("thresholds must be >= 0", err.Error())
+
+	// different combinations that combined are >1
+	st, err = NewWeighted("1/2", "1/2")
+	assert.Nil(err)
+	if assert.Len(st.conditions, 1) {
+		assert.Len(st.conditions[0], 2)
+		assert.Contains(st.conditions[0], big.NewRat(1, 2))
+	}
+
+	st, err = NewWeighted("1/2", "1/4", "1/4")
+	assert.Nil(err)
+	if assert.Len(st.conditions, 1) {
+		assert.Len(st.conditions[0], 3)
+		assert.Contains(st.conditions[0], big.NewRat(1, 2))
+		assert.Contains(st.conditions[0], big.NewRat(1, 4))
+	}
+
+	st, err = NewWeighted("1/2", "1/4", "1/4", "1")
+	assert.Nil(err)
+	if assert.Len(st.conditions, 1) {
+		assert.Len(st.conditions[0], 4)
+		assert.Contains(st.conditions[0], big.NewRat(1, 2))
+		assert.Contains(st.conditions[0], big.NewRat(1, 4))
+		assert.Contains(st.conditions[0], big.NewRat(1, 1))
+	}
+
+	// this is a weighted threshold
+	assert.True(st.Weighted())
+
+	// All thresholds must be staisfiable since they are treated as "AND" condiitons
+	st, err = NewMultiWeighted([]string{"1/2", "1/4"}, []string{"1"})
+	assert.Nil(st)
+	assert.Equal("threshold not statisfiable ([1/2 1/4])", err.Error())
+
+	st, err = NewMultiWeighted([]string{"1/2", "1/4", "1/4"}, []string{"-1"})
+	assert.Nil(st)
+	assert.Equal("thresholds must be >= 0", err.Error())
+
+	st, err = NewMultiWeighted([]string{"1/2", "1/4", "1/4"}, []string{"1"})
+	assert.Nil(err)
+	if assert.Len(st.conditions, 2) {
+		assert.Len(st.conditions[0], 3)
+		assert.Contains(st.conditions[0], big.NewRat(1, 2))
+		assert.Contains(st.conditions[0], big.NewRat(1, 4))
+
+		assert.Len(st.conditions[1], 1)
+		assert.Contains(st.conditions[1], big.NewRat(1, 1))
+	}
+
+	// this is a weighted threshold
+	assert.True(st.Weighted())
+
+}
+
+func TestJSONMarshalSigThreshold(t *testing.T) {
+	assert := assert.New(t)
+
+	st, _ := NewSigThreshold(1)
+	j, err := json.Marshal(st)
+	assert.Nil(err)
+	assert.Equal([]byte(`"1"`), j)
+
+	st, _ = NewSigThreshold(25)
+	j, err = json.Marshal(st)
+	assert.Nil(err)
+	assert.Equal([]byte(`"25"`), j)
+
+	st = &SigThreshold{}
+	j, err = json.Marshal(st)
+	assert.Nil(err)
+	assert.Equal([]byte(`"0"`), j)
+
+	st, _ = NewWeighted("1", "1/2", "1/4")
+	j, err = json.Marshal(st)
+	assert.Nil(err)
+	assert.Equal([]byte(`["1","1/2","1/4"]`), j)
+
+	st, _ = NewWeighted("1")
+	j, err = json.Marshal(st)
+	assert.Nil(err)
+	assert.Equal([]byte(`"1"`), j)
+
+	st, _ = NewMultiWeighted([]string{"1", "1/4", "1/2"}, []string{"1"})
+	j, err = json.Marshal(st)
+	assert.Nil(err)
+	assert.Equal([]byte(`[["1","1/4","1/2"],["1"]]`), j)
+
+	st, _ = NewMultiWeighted([]string{"1", "1/4", "1/2"})
+	j, err = json.Marshal(st)
+	assert.Nil(err)
+	assert.Equal([]byte(`["1","1/4","1/2"]`), j)
+}
+
+func TestJSONUnmarshalSigThreshold(t *testing.T) {
+	assert := assert.New(t)
+
+	st := &SigThreshold{}
+	err := json.Unmarshal([]byte(`"1"`), st)
+
+	assert.Nil(err)
+	if assert.Len(st.conditions, 1) {
+		assert.Len(st.conditions[0], 1)
+		assert.Contains(st.conditions[0], big.NewRat(1, 1))
+	}
+
+	st = &SigThreshold{}
+	err = json.Unmarshal([]byte(`["1"]`), st)
+
+	assert.Nil(err)
+	if assert.Len(st.conditions, 1) {
+		assert.Len(st.conditions[0], 1)
+		assert.Contains(st.conditions[0], big.NewRat(1, 1))
+	}
+
+	st = &SigThreshold{}
+	err = json.Unmarshal([]byte(`["1","1/4","1/2"]`), st)
+	assert.Nil(err)
+	if assert.Len(st.conditions, 1) {
+		assert.Len(st.conditions[0], 3)
+		assert.Contains(st.conditions[0], big.NewRat(1, 1))
+		assert.Contains(st.conditions[0], big.NewRat(1, 4))
+		assert.Contains(st.conditions[0], big.NewRat(1, 2))
+	}
+
+	st = &SigThreshold{}
+	err = json.Unmarshal([]byte(`[["1","1/4","1/2"],["1"]]`), st)
+	assert.Nil(err)
+	if assert.Len(st.conditions, 2) {
+		assert.Len(st.conditions[0], 3)
+		assert.Contains(st.conditions[0], big.NewRat(1, 1))
+		assert.Contains(st.conditions[0], big.NewRat(1, 4))
+		assert.Contains(st.conditions[0], big.NewRat(1, 2))
+		assert.Len(st.conditions[1], 1)
+		assert.Contains(st.conditions[0], big.NewRat(1, 1))
+	}
+
+	// if you throw bad stuff at us, we do our best to ignore your stupidity
+	// (i.e. pick one way and go with it - either weighted, or multi-weighted, but
+	// you cantz have both)
+	st = &SigThreshold{}
+	err = json.Unmarshal([]byte(`[["1","1/4","1/2"],"1"]`), st)
+	assert.Nil(err)
+	if assert.Len(st.conditions, 1) {
+		assert.Len(st.conditions[0], 3)
+		assert.Contains(st.conditions[0], big.NewRat(1, 1))
+		assert.Contains(st.conditions[0], big.NewRat(1, 4))
+		assert.Contains(st.conditions[0], big.NewRat(1, 2))
+	}
+
+	st = &SigThreshold{}
+	err = json.Unmarshal([]byte(`["1", ["1","1/4","1/2"]]`), st)
+	assert.Nil(err)
+	if assert.Len(st.conditions, 1) {
+		assert.Len(st.conditions[0], 1)
+		assert.Contains(st.conditions[0], big.NewRat(1, 1))
+	}
+}
+
+func TestSatisfied(t *testing.T) {
+	assert := assert.New(t)
+
+	st, _ := NewSigThreshold(3)
+	sigs := []derivation.Derivation{{KeyIndex: 0}}
+	assert.False(st.Satisfied(sigs))
+
+	sigs = []derivation.Derivation{{KeyIndex: 0}, {KeyIndex: 1}}
+	assert.False(st.Satisfied(sigs))
+
+	sigs = []derivation.Derivation{{KeyIndex: 0}, {KeyIndex: 1}, {KeyIndex: 2}}
+	assert.True(st.Satisfied(sigs))
+
+	st, _ = NewWeighted("1/2", "1/4", "1/4")
+	assert.True(st.Satisfied(sigs))
+
+	sigs = []derivation.Derivation{{KeyIndex: 0}}
+	assert.False(st.Satisfied(sigs))
+
+	sigs = []derivation.Derivation{{KeyIndex: 0}, {KeyIndex: 1}, {KeyIndex: 5}}
+	assert.False(st.Satisfied(sigs))
+
+	sigs = []derivation.Derivation{{KeyIndex: 2}, {KeyIndex: 1}}
+	assert.False(st.Satisfied(sigs))
+
+	st, _ = NewMultiWeighted([]string{"1/2", "1/2", "1/4", "1/4", "1/4", "1/4"}, []string{"1", "1"})
+
+	// meet the second but not the first
+	sigs = []derivation.Derivation{{KeyIndex: 1}, {KeyIndex: 4}}
+	assert.False(st.Satisfied(sigs))
+
+	// meet the first but not the second
+	sigs = []derivation.Derivation{{KeyIndex: 2}, {KeyIndex: 3}, {KeyIndex: 4}, {KeyIndex: 5}}
+	assert.False(st.Satisfied(sigs))
+
+	// pass
+	sigs = []derivation.Derivation{{KeyIndex: 0}, {KeyIndex: 2}, {KeyIndex: 3}, {KeyIndex: 4}, {KeyIndex: 5}}
+	assert.True(st.Satisfied(sigs))
+}


### PR DESCRIPTION
PR adds the following functionality:

* `kt` field supports simple thresholds along with weighted and multi-weighted thresholds
* Log now escrows duplicitous events
* Valid signatures that arrive after an event has already been applied to the log will be added to the total saved signatures for that event