### PR TITLE
updated escrow functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/decentralized-identity/kerigo
 go 1.13
 
 require (
-	github.com/aws/aws-sdk-go v1.35.7
 	github.com/google/tink/go v1.5.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/pkg/event/message.go
+++ b/pkg/event/message.go
@@ -1,12 +1,17 @@
 package event
 
-import "github.com/decentralized-identity/kerigo/pkg/derivation"
+import (
+	"time"
+
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+)
 
 // an event message holds the deserialized event
 // along with the provided signature
 type Message struct {
 	Event      *Event
 	Signatures []derivation.Derivation
+	Seen       time.Time
 }
 
 func (m Message) Serialize() ([]byte, error) {

--- a/pkg/log/escrow.go
+++ b/pkg/log/escrow.go
@@ -1,0 +1,90 @@
+package log
+
+import (
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+	"github.com/decentralized-identity/kerigo/pkg/event"
+)
+
+type Escrow map[string]*event.Message
+
+// Get returns the event message with all collected signatures
+// for the given event
+func (e Escrow) Get(evnt *event.Event) (*event.Message, error) {
+	digest, err := digestEvent(evnt)
+	if err != nil {
+		return nil, err
+	}
+
+	escrowed := &event.Message{Event: evnt}
+
+	if esc, ok := e[digest]; ok {
+		escrowed = esc
+	}
+
+	return escrowed, nil
+}
+
+// ForSequence returns all of the messages currently in escrow for the given sequence number
+func (e Escrow) ForSequence(sequence int) []*event.Message {
+	msgs := []*event.Message{}
+	for k, msg := range e {
+		if msg.Event.SequenceInt() == sequence {
+			msgs = append(msgs, e[k])
+		}
+	}
+
+	return msgs
+}
+
+// Add a message to the escrow
+func (e Escrow) Add(m *event.Message) error {
+	digest, err := digestEvent(m.Event)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := e[digest]; !ok {
+		e[digest] = m
+	} else {
+		e[digest].Signatures = mergeSignatures(e[digest].Signatures, m.Signatures)
+	}
+
+	return nil
+}
+
+// Clear all escrowed messages with the same sequence number
+// Escrowed events are indexed by the digest of their event - there could be
+// competeing versions of events if the prefix owner is being duplicitous, but
+// the first valid seen event always wins
+// Thus, this goes through and drops all competing events from the escrow
+// and returns them
+func (e Escrow) Clear(evnt event.Event) ([]*event.Message, error) {
+	sequence := evnt.SequenceInt()
+	digest, err := digestEvent(&evnt)
+	if err != nil {
+		return nil, err
+	}
+
+	delete(e, digest)
+
+	dups := []*event.Message{}
+	for i, msg := range e {
+		if msg.Event.SequenceInt() == sequence {
+			dups = append(dups, e[i])
+			delete(e, i)
+		}
+	}
+
+	return dups, nil
+}
+
+// digestEvent creates a standard digest of events to use as their index in
+// the escrow
+func digestEvent(evnt *event.Event) (string, error) {
+	serialized, err := evnt.Serialize()
+	if err != nil {
+		return "", err
+	}
+
+	return event.DigestString(serialized, derivation.Blake3256)
+}

--- a/pkg/log/escrow_test.go
+++ b/pkg/log/escrow_test.go
@@ -1,0 +1,152 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+	"github.com/decentralized-identity/kerigo/pkg/event"
+	"github.com/decentralized-identity/kerigo/pkg/prefix"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscrow(t *testing.T) {
+	assert := assert.New(t)
+
+	esc := Escrow(map[string]*event.Message{})
+
+	keys, err := newKeys(3)
+	if !assert.Nil(err) {
+		return
+	}
+	prefixes := []prefix.Prefix{}
+	for _, k := range keys {
+		prefixes = append(prefixes, k.pre)
+	}
+
+	// Create an event and add a signature
+	icp, err := event.NewInceptionEvent(event.WithDefaultVersion(event.JSON), event.WithKeys(prefixes...))
+	assert.Nil(err)
+
+	sig, err := derivation.New(derivation.WithCode(derivation.Ed25519Attached))
+	if !assert.Nil(err) {
+		return
+	}
+	sig.KeyIndex = 0
+
+	err = esc.Add(&event.Message{Event: icp, Signatures: []derivation.Derivation{*sig}})
+	assert.Nil(err)
+	assert.Len(esc, 1)
+
+	// Applying the same event should not increase escrow size or signature size
+	err = esc.Add(&event.Message{Event: icp, Signatures: []derivation.Derivation{*sig}})
+	assert.Nil(err)
+	if assert.Len(esc, 1) {
+		m, err := esc.Get(icp)
+		assert.Nil(err)
+		assert.Equal(icp, m.Event)
+		assert.Len(m.Signatures, 1)
+	}
+
+	sig2, err := derivation.New(derivation.WithCode(derivation.Ed25519Attached))
+	if !assert.Nil(err) {
+		return
+	}
+	sig2.KeyIndex = 1
+
+	// applying the same message again, but with a different signature, should add the sig
+	err = esc.Add(&event.Message{Event: icp, Signatures: []derivation.Derivation{*sig2}})
+	assert.Nil(err)
+	if assert.Len(esc, 1) {
+		m, err := esc.Get(icp)
+		assert.Nil(err)
+		assert.Equal(icp, m.Event)
+		assert.Len(m.Signatures, 2)
+	}
+
+	// create another event with different keys (though same in other respects)
+	keys2, err := newKeys(3)
+	if !assert.Nil(err) {
+		return
+	}
+	prefixes2 := []prefix.Prefix{}
+	for _, k := range keys2 {
+		prefixes2 = append(prefixes2, k.pre)
+	}
+
+	icp2, err := event.NewInceptionEvent(event.WithDefaultVersion(event.JSON), event.WithKeys(prefixes2...))
+	assert.Nil(err)
+
+	// adding another event - same type, seq, etc, but different keys, so this is a "different" event.
+	// Escrow should maintain them separately
+	err = esc.Add(&event.Message{Event: icp2, Signatures: []derivation.Derivation{*sig}})
+	assert.Nil(err)
+	if assert.Len(esc, 2) {
+		m, err := esc.Get(icp2)
+		assert.Equal(icp2, m.Event)
+		assert.Nil(err)
+		assert.Len(m.Signatures, 1)
+	}
+
+	// Add several more events to the escrow
+	ixn, err := event.NewEvent(
+		event.WithKeys(prefixes...),
+		event.WithSequence(1),
+		event.WithType(event.IXN),
+		event.WithDefaultVersion(event.JSON),
+	)
+	assert.Nil(err)
+
+	err = esc.Add(&event.Message{Event: ixn, Signatures: []derivation.Derivation{*sig}})
+	assert.Nil(err)
+	assert.Len(esc, 3)
+
+	ixn, err = event.NewEvent(
+		event.WithKeys(prefixes...),
+		event.WithSequence(2),
+		event.WithType(event.IXN),
+		event.WithDefaultVersion(event.JSON),
+	)
+	assert.Nil(err)
+
+	err = esc.Add(&event.Message{Event: ixn, Signatures: []derivation.Derivation{*sig}})
+	assert.Nil(err)
+	assert.Len(esc, 4)
+
+	ixn, err = event.NewEvent(
+		event.WithKeys(prefixes...),
+		event.WithSequence(3),
+		event.WithType(event.IXN),
+		event.WithDefaultVersion(event.JSON),
+	)
+	assert.Nil(err)
+
+	err = esc.Add(&event.Message{Event: ixn, Signatures: []derivation.Derivation{*sig}})
+	assert.Nil(err)
+	assert.Len(esc, 5)
+
+	// get the events for the sequence
+	msgs := esc.ForSequence(3)
+	if assert.Len(msgs, 1) {
+		assert.Equal(msgs[0].Event, ixn)
+		assert.Len(msgs[0].Signatures, 1)
+	}
+
+	msgs = esc.ForSequence(0)
+	assert.Len(msgs, 2)
+
+	// Clear events
+	esc.Clear(*ixn)
+	assert.Len(esc, 4)
+	msgs = esc.ForSequence(3)
+	assert.Empty(msgs)
+
+	// this should return
+	leftovers, err := esc.Clear(*icp)
+	assert.Nil(err)
+	if assert.Len(leftovers, 1) {
+		assert.Equal(leftovers[0].Event, icp2)
+	}
+	assert.Len(esc, 2)
+	msgs = esc.ForSequence(0)
+	assert.Empty(msgs)
+}


### PR DESCRIPTION
Splits out Escrow and implements tests for interface.

Updates `log.Apply` to automatically apply out of order Pending Events.

When a pending event is applied, any additional duplicitous events are moved to the duplicitous escrow.

go mod tidy

Closes #18 