### PR TITLE
Initial Keri package that represents the public API

### DIFF
--- a/cmd/demo/bob/bob.go
+++ b/cmd/demo/bob/bob.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/insecurecleartextkeyset"
+	"github.com/google/tink/go/keyset"
+	ed25519pb "github.com/google/tink/go/proto/ed25519_go_proto"
+	"github.com/google/tink/go/signature"
+	"github.com/google/tink/go/signature/subtle"
+
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+)
+
+func main() {
+	//client, err := net.Dial("tcp", ":5621")
+	//if err != nil {
+	//	panic(err)
+	//}
+	//
+	//ticker := time.Tick(3 * time.Second)
+	//
+	//written := 0
+	//for range ticker {
+	//	c, err := client.Write([]byte(`{"v":"KERI10JSON0000e6_" "i": "asdfasdfasdfsaf"`))
+	//	if err != nil {
+	//		panic(err)
+	//	}
+	//	written += c
+	//	fmt.Printf("wrote %d so far\n", written)
+	//}
+
+	handle, err := keyset.NewHandle(signature.ED25519KeyTemplate())
+	if err != nil {
+		panic(err)
+	}
+
+	buf := new(bytes.Buffer)
+	w := keyset.NewJSONWriter(buf)
+
+	err = insecurecleartextkeyset.Write(handle, w)
+	if err != nil {
+		panic(err)
+	}
+
+	//fmt.Println(string(buf.Bytes()))
+
+	der, err := derivation.FromPrefix("AgjD4nRlycmM5cPcAkfOATAp8wVldRsnc9f1tiwctXlw")
+	if err != nil {
+		panic(err)
+	}
+	privkey := ed25519.NewKeyFromSeed(der.Raw)
+
+	oldsig, _ := subtle.NewED25519SignerFromPrivateKey(&privkey)
+	oldb, err := oldsig.Sign([]byte("I<3keri"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(base64.StdEncoding.EncodeToString(oldb))
+
+	b, err := NewKeyHandle(der.Raw)
+	if err != nil {
+		panic(err)
+	}
+
+	keyJson := `{"primaryKeyId":1093351049,"key":[{"keyData":{"typeUrl":"type.googleapis.com/google.crypto.tink.Ed25519PrivateKey","value":"%s","keyMaterialType":"ASYMMETRIC_PRIVATE"},"status":"ENABLED","keyId":1093351049,"outputPrefixType":"RAW"}]}`
+
+	newKeyJs := fmt.Sprintf(keyJson, b)
+
+	r := keyset.NewJSONReader(bytes.NewBuffer([]byte(newKeyJs)))
+	newh, err := insecurecleartextkeyset.Read(r)
+	if err != nil {
+		panic(err)
+	}
+
+	sig, _ := signature.NewSigner(newh)
+	newb, err := sig.Sign([]byte("I<3keri"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(base64.StdEncoding.EncodeToString(newb))
+
+	//pubKH, err := newh.Public()
+	//if err != nil {
+	//	panic(err)
+	//}
+	//buf = new(bytes.Buffer)
+	//pubKeyWriter := keyset.NewJSONWriter(buf)
+	//
+	//err = pubKH.WriteWithNoSecrets(pubKeyWriter)
+	//if err != nil {
+	//	panic(err)
+	//}
+	//
+	//fmt.Println(buf.Len())
+	//
+	//fmt.Println(string(buf.Bytes()))
+	//
+}
+
+func NewKeyHandle(seed []byte) ([]byte, error) {
+	private, err := newKey(seed)
+	if err != nil {
+		return nil, err
+	}
+	serializedKey, err := proto.Marshal(private.(proto.Message))
+	if err != nil {
+		return nil, err
+	}
+
+	s := base64.StdEncoding.EncodeToString(serializedKey)
+	return []byte(s), nil
+}
+
+func newKey(seed []byte) (proto.Message, error) {
+	private := ed25519.NewKeyFromSeed(seed)
+	public := private.Public()
+
+	publicProto := &ed25519pb.Ed25519PublicKey{
+		Version:  0,
+		KeyValue: public.(ed25519.PublicKey),
+	}
+	privateProto := &ed25519pb.Ed25519PrivateKey{
+		Version:   0,
+		PublicKey: publicProto,
+		KeyValue:  private.Seed(),
+	}
+
+	return privateProto, nil
+}

--- a/cmd/demo/eve/eve.go
+++ b/cmd/demo/eve/eve.go
@@ -57,7 +57,7 @@ func main() {
 
 	fmt.Printf("Direct Mode demo of Eve as %s on TCP port 5621 to port 5620\n\n\n", kerl.Prefix())
 
-	err = kerl.HandleInboundDirect(inb)
+	err = kerl.HandleDirect(inb)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/demo/eve/eve.go
+++ b/cmd/demo/eve/eve.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/keyset"
+
+	"github.com/decentralized-identity/kerigo/pkg/db/mem"
+	"github.com/decentralized-identity/kerigo/pkg/io/stream"
+	"github.com/decentralized-identity/kerigo/pkg/keri"
+	"github.com/decentralized-identity/kerigo/pkg/keymanager"
+)
+
+var (
+	secrets = []string{
+		"AgjD4nRlycmM5cPcAkfOATAp8wVldRsnc9f1tiwctXlw",
+		"AKUotEE0eAheKdDJh9QvNmSEmO_bjIav8V_GmctGpuCQ",
+		"AK-nVhMMJciMPvmF5VZE_9H-nhrgng9aJWf7_UHPtRNM",
+		"AT2cx-P5YUjIw_SLCHQ0pqoBWGk9s4N1brD-4pD_ANbs",
+		"Ap5waegfnuP6ezC18w7jQiPyQwYYsp9Yv9rYMlKAYL8k",
+		"Aqlc_FWWrxpxCo7R12uIz_Y2pHUH2prHx1kjghPa8jT8",
+		"AagumsL8FeGES7tYcnr_5oN6qcwJzZfLKxoniKUpG4qc",
+		"ADW3o9m3udwEf0aoOdZLLJdf1aylokP0lwwI_M2J9h0s",
+	}
+	km *keymanager.KeyManager
+)
+
+func main() {
+
+	inb, err := stream.NewStreamInbound(":5621")
+	if err != nil {
+		panic(err)
+	}
+
+	store := mem.NewMemDB()
+
+	kh, err := keyset.NewHandle(aead.AES256GCMKeyTemplate())
+	if err != nil {
+		panic(err)
+	}
+
+	a, err := aead.New(kh)
+	if err != nil {
+		panic(err)
+	}
+
+	km, err = keymanager.NewKeyManager(a, store, keymanager.WithSecrets(secrets))
+	if err != nil {
+		panic(err)
+	}
+
+	kerl, err := keri.New(km)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Direct Mode demo of Eve as %s on TCP port 5621 to port 5620\n\n\n", kerl.Prefix())
+
+	err = kerl.HandleInboundDirect(inb)
+	if err != nil {
+		panic(err)
+	}
+
+	ch := make(chan bool)
+	<-ch
+
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.0
+	github.com/golang/protobuf v1.4.2
 	github.com/google/tink/go v1.5.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/decentralized-identity/kerigo
 go 1.13
 
 require (
+	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/google/tink/go v1.5.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,10 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/aws/aws-sdk-go v1.35.7 h1:FHMhVhyc/9jljgFAcGkQDYjpC9btM0B8VfkLBfctdNE=
 github.com/aws/aws-sdk-go v1.35.7/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/cenkalti/backoff v1.1.0 h1:QnvVp8ikKCDWOsFheytRCoYWYPO/ObCTBGxT19Hc+yE=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1,6 +1,20 @@
 package db
 
+import (
+	"github.com/decentralized-identity/kerigo/pkg/event"
+)
+
 type DB interface {
 	Put(k string, v []byte) error
 	Get(k string) ([]byte, error)
+
+	AddVRCs(key string, vrcs []*event.Event) error
+	AddVRC(key string, vrcs *event.Event) error
+	GetVRCs(key string) ([]*event.Event, error)
+	ListVCRs(key string) (Iterator, error)
+	VCRCount(key string) (int, error)
+	DeleteVRCs(key string) error
+}
+
+type Iterator interface {
 }

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1,19 +1,8 @@
 package db
 
-import (
-	"github.com/decentralized-identity/kerigo/pkg/event"
-)
-
 type DB interface {
 	Put(k string, v []byte) error
 	Get(k string) ([]byte, error)
-
-	AddVRCs(key string, vrcs []*event.Event) error
-	AddVRC(key string, vrcs *event.Event) error
-	GetVRCs(key string) ([]*event.Event, error)
-	ListVCRs(key string) (Iterator, error)
-	VCRCount(key string) (int, error)
-	DeleteVRCs(key string) error
 }
 
 type Iterator interface {

--- a/pkg/derivation/code.go
+++ b/pkg/derivation/code.go
@@ -1,6 +1,8 @@
 package derivation
 
-import "strings"
+import (
+	"strings"
+)
 
 type Code int
 
@@ -192,7 +194,7 @@ func (c Code) Name() string {
 // Default derivation data: used for calculating total data length
 // in some KERI functions
 func (c Code) Default() string {
-	return string(append([]byte(c.String()), []byte(strings.Repeat("A", c.PrefixBase64Length()-len(c.String())))...))
+	return strings.Repeat("#", c.PrefixBase64Length())
 }
 
 // SelfAdressing derivaitons

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -104,7 +104,7 @@ type Event struct {
 	Cut                           []string       `json:"wr,omitempty"`
 	Config                        []prefix.Trait `json:"c,omitempty"`
 	Permissions                   []interface{}  `json:"perm,omitempty"`
-	Seals                         []*Seal        `json:"a,omitempty"`
+	Seals                         SealArray      `json:"a,omitempty"`
 	DelegatorSeal                 *Seal          `json:"da,omitempty"`
 }
 
@@ -123,7 +123,7 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 	switch e.EventType {
 
 	case ROT.String(), DRT.String():
-		// roation events need cuts, adds, and data
+		// rotation events need cuts, adds, and data
 		if e.Cut == nil {
 			e.Cut = []string{}
 		}
@@ -131,14 +131,14 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 			e.Add = []string{}
 		}
 		if e.Seals == nil {
-			e.Seals = []*Seal{}
+			e.Seals = SealArray{}
 		}
 
 		return json.Marshal(&struct {
 			*EventAlias
-			Cut   []string `json:"wr"`
-			Add   []string `json:"wa"`
-			Seals []*Seal  `json:"a"`
+			Cut   []string  `json:"wr"`
+			Add   []string  `json:"wa"`
+			Seals SealArray `json:"a"`
 		}{
 			EventAlias: (*EventAlias)(e),
 			Cut:        e.Cut,
@@ -149,11 +149,11 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 	case IXN.String():
 		// IXN events need data
 		if e.Seals == nil {
-			e.Seals = []*Seal{}
+			e.Seals = SealArray{}
 		}
 		return json.Marshal(&struct {
 			*EventAlias
-			Seals []*Seal `json:"a"`
+			Seals SealArray `json:"a"`
 		}{
 			EventAlias: (*EventAlias)(e),
 			Seals:      e.Seals,
@@ -179,7 +179,7 @@ func (e *Event) MarshalJSON() ([]byte, error) {
 		})
 	case VRC.String():
 		// Receipt news single Seal
-		if e.Seals == nil || len(e.Seals) != 1 {
+		if e.Seals == nil {
 			return nil, errors.New("unable to serialize a receipt without a seal")
 		}
 
@@ -317,6 +317,7 @@ func Deserialize(data []byte, from FORMAT) (*Event, error) {
 		evt := &Event{}
 		err := json.Unmarshal(data, evt)
 		if err != nil {
+			fmt.Println(string(data))
 			return nil, errors.Wrap(err, "unable to unmarshal event from JSON")
 		}
 		return evt, nil

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -239,7 +239,7 @@ func (e *Event) WitnessDerivation(index int) (*derivation.Derivation, error) {
 }
 
 func (e *Event) GetDigest() (string, error) {
-	ser, err := Serialize(e, EDS)
+	ser, err := e.Serialize()
 
 	der, err := derivation.New(derivation.WithCode(derivation.Blake3256))
 	if err != nil {
@@ -317,7 +317,6 @@ func Deserialize(data []byte, from FORMAT) (*Event, error) {
 		evt := &Event{}
 		err := json.Unmarshal(data, evt)
 		if err != nil {
-			fmt.Println(string(data))
 			return nil, errors.Wrap(err, "unable to unmarshal event from JSON")
 		}
 		return evt, nil

--- a/pkg/event/inception.go
+++ b/pkg/event/inception.go
@@ -1,0 +1,56 @@
+package event
+
+import (
+	"crypto/ed25519"
+	"fmt"
+
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+	"github.com/decentralized-identity/kerigo/pkg/prefix"
+	"github.com/decentralized-identity/kerigo/pkg/version"
+)
+
+func Incept(signing ed25519.PublicKey, next *derivation.Derivation) (*Event, error) {
+	keyDer, err := derivation.New(derivation.WithCode(derivation.Ed25519), derivation.WithRaw(signing))
+	if err != nil {
+		return nil, err
+	}
+	keyPre := prefix.New(keyDer)
+
+	nextKeyPre := prefix.New(next)
+
+	icp, err := NewInceptionEvent(WithKeys(keyPre), WithDefaultVersion(JSON), WithNext(1, derivation.Blake3256, nextKeyPre))
+	if err != nil {
+		return nil, err
+	}
+
+	// Serialize with defaults to get correct length for version string
+	icp.Prefix = derivation.Blake3256.Default()
+	icp.Version = DefaultVersionString(JSON)
+	eventBytes, err := Serialize(icp, JSON)
+	if err != nil {
+		return nil, err
+	}
+
+	icp.Version = VersionString(JSON, version.Code(), len(eventBytes))
+
+	ser, err := Serialize(icp, JSON)
+	fmt.Println(string(ser))
+
+	saDerivation, err := derivation.New(derivation.WithCode(derivation.Blake3256))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = saDerivation.Derive(ser)
+	if err != nil {
+		return nil, err
+	}
+
+	selfAdd := prefix.New(saDerivation)
+	selfAddAID := selfAdd.String()
+
+	// Set as the prefix for the inception event
+	icp.Prefix = selfAddAID
+
+	return icp, nil
+}

--- a/pkg/event/inception.go
+++ b/pkg/event/inception.go
@@ -2,7 +2,6 @@ package event
 
 import (
 	"crypto/ed25519"
-	"fmt"
 
 	"github.com/decentralized-identity/kerigo/pkg/derivation"
 	"github.com/decentralized-identity/kerigo/pkg/prefix"
@@ -34,7 +33,9 @@ func Incept(signing ed25519.PublicKey, next *derivation.Derivation) (*Event, err
 	icp.Version = VersionString(JSON, version.Code(), len(eventBytes))
 
 	ser, err := Serialize(icp, JSON)
-	fmt.Println(string(ser))
+	if err != nil {
+		return nil, err
+	}
 
 	saDerivation, err := derivation.New(derivation.WithCode(derivation.Blake3256))
 	if err != nil {

--- a/pkg/event/inception_test.go
+++ b/pkg/event/inception_test.go
@@ -1,0 +1,38 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/keyset"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/decentralized-identity/kerigo/pkg/db/mem"
+	"github.com/decentralized-identity/kerigo/pkg/keymanager"
+)
+
+func TestIncept(t *testing.T) {
+	secrets := []string{"ADW3o9m3udwEf0aoOdZLLJdf1aylokP0lwwI_M2J9h0s", "AagumsL8FeGES7tYcnr_5oN6qcwJzZfLKxoniKUpG4qc"}
+	kms := getKMS(t, secrets)
+
+	icp, err := Incept(kms.PublicKey(), kms.Next())
+	assert.NoError(t, err)
+
+	assert.Equal(t, "Eh0fefvTQ55Jwps4dVnIekf7mZgWoU8bCUsDsKeGiEgU", icp.Prefix)
+	assert.Equal(t, "D69EflciVP9zgsihNU14Dbm2bPXoNGxKHK_BBVFMQ-YU", icp.Keys[0])
+	assert.Equal(t, "E2N7cav-AXF8R86YPUWqo8oGu2YcdyFz_w6lTiNmmOY4", icp.Next)
+}
+
+func getKMS(t *testing.T, secrets []string) *keymanager.KeyManager {
+
+	kh, err := keyset.NewHandle(aead.AES256GCMKeyTemplate())
+	assert.NoError(t, err)
+
+	a, err := aead.New(kh)
+	assert.NoError(t, err)
+
+	km, err := keymanager.NewKeyManager(a, mem.NewMemDB(), keymanager.WithSecrets(secrets))
+	assert.NoError(t, err)
+
+	return km
+}

--- a/pkg/event/main.go
+++ b/pkg/event/main.go
@@ -198,27 +198,6 @@ func NewInceptionEvent(opts ...EventOption) (*Event, error) {
 	return e, nil
 }
 
-// NewRotationEvent returns and incpetion configured with the provided parameters
-// New Rotation Events will have empty 'v' and 'i' strings
-func NewRotationEvent(opts ...EventOption) (*Event, error) {
-	e := &Event{
-		EventType:                     ilkString[ICP],
-		Sequence:                      "0",
-		SigningThreshold:              "1",
-		AccountableDuplicityThreshold: "0",
-		Witnesses:                     []string{},
-		Config:                        []prefix.Trait{},
-	}
-	for _, o := range opts {
-		err := o(e)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return e, nil
-}
-
 // NewEvent returns a new event with the specified options applied
 func NewEvent(opts ...EventOption) (*Event, error) {
 	st, _ := NewSigThreshold(1)

--- a/pkg/event/main.go
+++ b/pkg/event/main.go
@@ -198,6 +198,27 @@ func NewInceptionEvent(opts ...EventOption) (*Event, error) {
 	return e, nil
 }
 
+// NewRotationEvent returns and incpetion configured with the provided parameters
+// New Rotation Events will have empty 'v' and 'i' strings
+func NewRotationEvent(opts ...EventOption) (*Event, error) {
+	e := &Event{
+		EventType:                     ilkString[ICP],
+		Sequence:                      "0",
+		SigningThreshold:              "1",
+		AccountableDuplicityThreshold: "0",
+		Witnesses:                     []string{},
+		Config:                        []prefix.Trait{},
+	}
+	for _, o := range opts {
+		err := o(e)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return e, nil
+}
+
 // NewEvent returns a new event with the specified options applied
 func NewEvent(opts ...EventOption) (*Event, error) {
 	st, _ := NewSigThreshold(1)

--- a/pkg/event/receipt.go
+++ b/pkg/event/receipt.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/decentralized-identity/kerigo/pkg/derivation"
+	"github.com/decentralized-identity/kerigo/pkg/version"
 )
 
 // Recipt generates a receipt for the provided event
@@ -35,6 +36,13 @@ func TransferableReceipt(event *Event, estEvent *Event, code derivation.Code) (*
 		return nil, err
 	}
 	receipt.Digest = eventDigest
+
+	eventBytes, err := Serialize(receipt, JSON)
+	if err != nil {
+		return nil, err
+	}
+
+	receipt.Version = VersionString(JSON, version.Code(), len(eventBytes))
 
 	return receipt, nil
 }

--- a/pkg/event/receipt_test.go
+++ b/pkg/event/receipt_test.go
@@ -39,8 +39,7 @@ func TestTransferable(t *testing.T) {
 	vrcBytes, err := vrc.Serialize()
 	assert.NoError(t, err)
 
-	//TODO:  get the seal digest of the last establishment event to match
-	assert.Equal(t, len(expectedVRCBytes), len(vrcBytes))
+	assert.Equal(t, expectedVRCBytes, string(vrcBytes))
 }
 
 func incept(t *testing.T, secret, next string) *Event {

--- a/pkg/event/receipt_test.go
+++ b/pkg/event/receipt_test.go
@@ -21,8 +21,8 @@ func TestTransferable(t *testing.T) {
 	remoteICP := incept(t, remoteSecret, remoteNext)
 	estEvent := incept(t, localSecret, localNext)
 
-	icpBytes := `{"v":"KERI10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}`
-	expectedVRCBytes := `{"v":"KERI10JSON000105_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"vrc","d":"E9ZTKOhr-lqB7jbBMBpUIdMpfWvEswoMoc5UrwCRcTSc","a":{"i":"EmGTyV9unQ59uIQIYv6Vsc7KweyTbplfumEV-IB33bEg","s":"0","d":"E-_qFJZK8ER6rJA7W4WR2xxSwKT1RLi8yCCyZ0XHTnLU"}}`
+	icpBytes := `{"v":"KERI10JSON0000e6_","i":"Ep9IFLmnLTwz_EfZCXOuVHcYFmoHNKgqz7nQ1ItKX9pc","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}`
+	expectedVRCBytes := `{"v":"KERI10JSON000105_","i":"Ep9IFLmnLTwz_EfZCXOuVHcYFmoHNKgqz7nQ1ItKX9pc","s":"0","t":"vrc","d":"EBSQD8MrJi-qTF--fg1hMT7a-sVacyFjeaPn3FduKNsc","a":{"i":"E482bsaPDuLO25ilSJkErz-Xqmw4knyAZd1Ah01do9k0","s":"0","d":"Ej2wcLnGA6DJHhF3f08nIIhoZncG2O1pVKgFvWLPDFjg"}}`
 
 	d, _ := json.Marshal(remoteICP)
 	assert.JSONEq(t, icpBytes, string(d))

--- a/pkg/event/seal.go
+++ b/pkg/event/seal.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/decentralized-identity/kerigo/pkg/derivation"
 )
@@ -160,4 +161,14 @@ func (r *SealArray) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(a)
+}
+
+// SequenceInt returns an integer representation of the
+// hex sequence string
+func (r *Seal) SequenceInt() int {
+	eInt, err := strconv.ParseInt(r.Sequence, 16, 64)
+	if err != nil {
+		return -1
+	}
+	return int(eInt)
 }

--- a/pkg/event/seal_test.go
+++ b/pkg/event/seal_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,4 +68,12 @@ func TestSealEstablishment(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBytes, string(sealBytes))
 
+}
+
+func TestSealSequenceInt(t *testing.T) {
+	s := &Seal{Sequence: "4"}
+	assert.Equal(t, 4, s.SequenceInt())
+
+	s.Sequence = fmt.Sprintf("%x", 93840482)
+	assert.Equal(t, 93840482, s.SequenceInt())
 }

--- a/pkg/event/seal_test.go
+++ b/pkg/event/seal_test.go
@@ -51,9 +51,10 @@ func TestEventLocationSeal(t *testing.T) {
 }
 
 func TestSealEstablishment(t *testing.T) {
-	expectedBytes := `{"i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","d":"EW3x3YgiqRUhHq1arcoqm8k1A1rqeyexeZMVLrz2JkXc"}`
+	expectedBytes := `{"i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","d":"EwUK1OhZGRyPaAt5Td-JzZkzSaDscKd_CtEKeUuwreHQ"}`
 
 	evt := &Event{
+		Version:   "KERI10JSON0000e6_",
 		Prefix:    "ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY",
 		Sequence:  "0",
 		EventType: "icp",

--- a/pkg/io/inbound.go
+++ b/pkg/io/inbound.go
@@ -8,6 +8,9 @@ type InboundTransport interface {
 	// Start starts the inbound transport.  It returns a channel of event.Messages or an error
 	Start() (<-chan *event.Message, error)
 
+	// Write writes the serialized bytes of the message
+	Write(msg *event.Message) error
+
 	// Stop halts the inbound transport
 	Stop()
 }

--- a/pkg/io/stream/conn.go
+++ b/pkg/io/stream/conn.go
@@ -1,0 +1,65 @@
+package stream
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+	"github.com/decentralized-identity/kerigo/pkg/event"
+)
+
+func handleConnection(conn io.Reader, ch chan *event.Message) error {
+	c := bufio.NewReader(conn)
+
+	for {
+		// read a min sized buffer which contains the message length
+		h, err := c.Peek(MinSniffSize)
+		if err != nil {
+			return fmt.Errorf("short peek: (%v)", err)
+		}
+
+		submatches := Rever.FindStringSubmatch(string(h))
+		if len(submatches) != 5 {
+			return errors.New("invalid version string")
+		}
+
+		ser := strings.TrimSpace(submatches[3])
+		hex := submatches[4]
+
+		size, err := strconv.ParseInt(hex, 16, 64)
+		if err != nil {
+			return errors.Wrap(err, "invalid message size hex")
+		}
+
+		f, err := event.Format(ser)
+		if err != nil {
+			return err
+		}
+
+		buff := make([]byte, size)
+		_, err = io.ReadFull(c, buff)
+		if err != nil {
+			return err
+		}
+
+		msg := &event.Message{}
+		msg.Event, err = event.Deserialize(buff, f)
+		if err != nil {
+			return fmt.Errorf("unable to unmarshal event: (%v)", err)
+		}
+
+		sigs, err := derivation.ParseAttachedSignatures(c)
+		if err != nil {
+			return fmt.Errorf("error parsing sigs: %v", err)
+		}
+
+		msg.Signatures = sigs
+
+		ch <- msg
+	}
+}

--- a/pkg/io/stream/inbound.go
+++ b/pkg/io/stream/inbound.go
@@ -1,20 +1,15 @@
 package stream
 
 import (
-	"bufio"
-	"fmt"
-	"io"
 	"log"
 	"net"
 	"regexp"
-	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
 
-	"github.com/decentralized-identity/kerigo/pkg/derivation"
 	"github.com/decentralized-identity/kerigo/pkg/event"
+	"github.com/decentralized-identity/kerigo/pkg/io"
 )
 
 const (
@@ -27,6 +22,11 @@ const (
 	MessageBufferSize = 5
 )
 
+type conn struct {
+	ch   chan *event.Message
+	conn net.Conn
+}
+
 var (
 	Rever = regexp.MustCompile(Verex)
 )
@@ -35,19 +35,19 @@ type Inbound struct {
 	addr string
 
 	connLock sync.Mutex
-	conns    []net.Conn
+	conns    []*conn
 
-	ch chan *event.Message
+	ch chan io.Conn
 }
 
 func NewStreamInbound(addr string) (*Inbound, error) {
 	return &Inbound{
 		addr: addr,
-		ch:   make(chan *event.Message, MessageBufferSize),
+		ch:   make(chan io.Conn, 1),
 	}, nil
 }
 
-func (r *Inbound) Start() (<-chan *event.Message, error) {
+func (r *Inbound) Start() (<-chan io.Conn, error) {
 	ln, err := net.Listen("tcp", r.addr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to listen on %s", r.addr)
@@ -55,17 +55,23 @@ func (r *Inbound) Start() (<-chan *event.Message, error) {
 
 	go func() {
 		for {
-			conn, err := ln.Accept()
+			c, err := ln.Accept()
 			if err != nil {
 				log.Printf("unexpected error accepting connection: %v", err)
 				continue
 			}
 
-			r.addConnection(conn)
+			ioc := &conn{
+				conn: c,
+				ch:   make(chan *event.Message, MessageBufferSize),
+			}
+
+			r.addConnection(ioc)
+			r.ch <- ioc
 			go func() {
-				err := r.handleConnection(conn)
-				r.removeConnection(conn)
-				log.Printf("connection closed with err: %v\n", err)
+				err := handleConnection(ioc.conn, ioc.ch)
+				r.removeConnection(ioc)
+				log.Printf("inbound connection closed with err: %v\n", err)
 			}()
 		}
 	}()
@@ -78,71 +84,21 @@ func (r *Inbound) Stop() {
 	defer r.connLock.Unlock()
 
 	for _, conn := range r.conns {
-		_ = conn.Close()
+		_ = conn.conn.Close()
+		close(conn.ch)
 	}
 
 	close(r.ch)
 }
 
-func (r *Inbound) handleConnection(conn io.Reader) error {
-	c := bufio.NewReader(conn)
-
-	for {
-		// read a min sized buffer which contains the message length
-		h, err := c.Peek(MinSniffSize)
-		if err != nil {
-			return fmt.Errorf("short peek: (%v)", err)
-		}
-
-		submatches := Rever.FindStringSubmatch(string(h))
-		if len(submatches) != 5 {
-			return errors.New("invalid version string")
-		}
-
-		ser := strings.TrimSpace(submatches[3])
-		hex := submatches[4]
-
-		size, err := strconv.ParseInt(hex, 16, 64)
-		if err != nil {
-			return errors.Wrap(err, "invalid message size hex")
-		}
-
-		f, err := event.Format(ser)
-		if err != nil {
-			return err
-		}
-
-		buff := make([]byte, size)
-		_, err = io.ReadFull(c, buff)
-		if err != nil {
-			return err
-		}
-
-		msg := &event.Message{}
-		msg.Event, err = event.Deserialize(buff, f)
-		if err != nil {
-			return fmt.Errorf("unable to unmarshal event: (%v)", err)
-		}
-
-		sigs, err := derivation.ParseAttachedSignatures(c)
-		if err != nil {
-			return fmt.Errorf("error parsing sigs: %v", err)
-		}
-
-		msg.Signatures = sigs
-
-		r.ch <- msg
-	}
-}
-
-func (r *Inbound) addConnection(conn net.Conn) {
+func (r *Inbound) addConnection(conn *conn) {
 	r.connLock.Lock()
 	defer r.connLock.Unlock()
 
 	r.conns = append(r.conns, conn)
 }
 
-func (r *Inbound) removeConnection(conn net.Conn) {
+func (r *Inbound) removeConnection(conn *conn) {
 	r.connLock.Lock()
 	defer r.connLock.Unlock()
 
@@ -159,13 +115,29 @@ func (r *Inbound) removeConnection(conn net.Conn) {
 	}
 }
 
+// Write the message to all currently active connections
 func (r *Inbound) Write(msg *event.Message) error {
+	for _, c := range r.conns {
+		err := c.Write(msg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *conn) Msgs() chan *event.Message {
+	return r.ch
+}
+
+func (r *conn) Write(msg *event.Message) error {
 	data, err := msg.Serialize()
 	if err != nil {
 		return errors.Wrap(err, "unable to serialize message for stream outbound")
 	}
 
-	_, err = r.conns[0].Write(data)
+	_, err = r.conn.Write(data)
 	if err != nil {
 		return errors.Wrap(err, "unable to right message to stream outbound")
 	}

--- a/pkg/io/stream/outbound.go
+++ b/pkg/io/stream/outbound.go
@@ -1,0 +1,76 @@
+package stream
+
+import (
+	"context"
+	"log"
+	"net"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pkg/errors"
+
+	"github.com/decentralized-identity/kerigo/pkg/event"
+	kio "github.com/decentralized-identity/kerigo/pkg/io"
+)
+
+type Outbound struct {
+	ioc     *conn
+	addr    string
+	timeout time.Duration
+}
+
+func NewStreamOutbound(addr string, timeout time.Duration) (*Outbound, error) {
+
+	o := &Outbound{
+		addr:    addr,
+		timeout: timeout,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	err := backoff.Retry(func() error {
+		var err error
+		c, err := net.Dial("tcp", addr)
+		if err != nil {
+			return errors.Wrap(err, "unable to connect")
+		}
+
+		o.ioc = &conn{
+			ch:   make(chan *event.Message, MessageBufferSize),
+			conn: c,
+		}
+		return nil
+	}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
+
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to connect after timeout")
+	}
+
+	return o, nil
+}
+
+func (r *Outbound) Start() (<-chan kio.Conn, error) {
+	ch := make(chan kio.Conn, 1)
+	ch <- r.ioc
+	go func() {
+		err := handleConnection(r.ioc.conn, r.ioc.ch)
+		log.Printf("outbound connection closed with err: %v\n", err)
+	}()
+
+	return ch, nil
+}
+
+func (r *Outbound) Write(msg *event.Message) error {
+	err := r.ioc.Write(msg)
+	if err != nil {
+		return errors.Wrap(err, "unable to right message to stream outbound")
+	}
+
+	return nil
+}
+
+func (r *Outbound) Stop() {
+	_ = r.ioc.conn.Close()
+	close(r.ioc.ch)
+}

--- a/pkg/io/stream/outbound_test.go
+++ b/pkg/io/stream/outbound_test.go
@@ -3,21 +3,26 @@ package stream
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSingleMessage(t *testing.T) {
-	addr := ":5601"
+func TestSingleOutMessage(t *testing.T) {
+	addr := ":5701"
 	d := []byte(`{"v":"KERI10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
 
-	target, err := NewStreamInbound(addr)
+	write := startServer(t, addr)
+	target, err := NewStreamOutbound(addr, 5*time.Second)
 	assert.NoError(t, err)
 
 	ch, err := target.Start()
 	assert.NoError(t, err)
 
-	sendMsg(t, addr, d)
+	assert.NoError(t, err)
+
+	write(d)
 
 	conn := <-ch
 
@@ -29,18 +34,20 @@ func TestSingleMessage(t *testing.T) {
 	target.Stop()
 }
 
-func TestMultipleMessages(t *testing.T) {
-	addr := ":5602"
+func TestMultipleOutMessages(t *testing.T) {
+	addr := ":5702"
 	d := []byte(`{"v":"KERI10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
 	d2 := []byte(`{"v":"KERI10JSON000122_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"1","t":"rot","p":"E9ZTKOhr-lqB7jbBMBpUIdMpfWvEswoMoc5UrwCRcTSc","kt":"1","k":["DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI"],"n":"E-dapdcC6XR1KWmWDsNl4J_OxcGxNZw1Xd95JH5a34fI","wt":"0","wr":[],"wa":[],"a":[]}-AABAA91xjNugSykLy0_IZsvkUxkVnZVlNqqhhZT5_VT9wK0pccNrD6i_3h_lTK5ZmXr0wsN6zn-4KMw3ZtYQ2bjbuDQ`)
 
-	target, err := NewStreamInbound(addr)
+	write := startServer(t, addr)
+	target, err := NewStreamOutbound(addr, 5*time.Second)
 	assert.NoError(t, err)
 
 	ch, err := target.Start()
 	assert.NoError(t, err)
 
-	sendMsg(t, addr, d, d2)
+	write(d)
+	write(d2)
 
 	conn := <-ch
 
@@ -57,18 +64,20 @@ func TestMultipleMessages(t *testing.T) {
 	target.Stop()
 }
 
-func TestMultipleWrites(t *testing.T) {
-	addr := ":5603"
+func TestMultipleOutWrites(t *testing.T) {
+	addr := ":5703"
 	d := []byte(`{"v":"KERI`)
 	d2 := []byte(`10JSON000122_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"1","t":"rot","p":"E9ZTKOhr-lqB7jbBMBpUIdMpfWvEswoMoc5UrwCRcTSc","kt":"1","k":["DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI"],"n":"E-dapdcC6XR1KWmWDsNl4J_OxcGxNZw1Xd95JH5a34fI","wt":"0","wr":[],"wa":[],"a":[]}-AABAA91xjNugSykLy0_IZsvkUxkVnZVlNqqhhZT5_VT9wK0pccNrD6i_3h_lTK5ZmXr0wsN6zn-4KMw3ZtYQ2bjbuDQ`)
 
-	target, err := NewStreamInbound(addr)
+	write := startServer(t, addr)
+	target, err := NewStreamOutbound(addr, 5*time.Second)
 	assert.NoError(t, err)
 
 	ch, err := target.Start()
 	assert.NoError(t, err)
 
-	sendMsg(t, addr, d, d2)
+	write(d)
+	write(d2)
 
 	conn := <-ch
 
@@ -80,66 +89,83 @@ func TestMultipleWrites(t *testing.T) {
 	target.Stop()
 }
 
-func TestBadData(t *testing.T) {
+func TestBadOutData(t *testing.T) {
 	t.Run("bad version string", func(t *testing.T) {
-		addr := ":5604"
+		addr := ":5704"
 		d := []byte(`{"v":"KERL10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
 
-		target, err := NewStreamInbound(addr)
+		write := startServer(t, addr)
+		target, err := NewStreamOutbound(addr, 5*time.Second)
 		assert.NoError(t, err)
 
 		_, err = target.Start()
 		assert.NoError(t, err)
 
-		sendMsg(t, addr, d)
+		write(d)
 	})
 	t.Run("bad format string", func(t *testing.T) {
-		addr := ":5605"
+		addr := ":5705"
 		d := []byte(`{"v":"KERI10PROT0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
 
-		target, err := NewStreamInbound(addr)
+		write := startServer(t, addr)
+		target, err := NewStreamOutbound(addr, 5*time.Second)
 		assert.NoError(t, err)
 
 		_, err = target.Start()
 		assert.NoError(t, err)
 
-		sendMsg(t, addr, d)
+		write(d)
 	})
 	t.Run("bad JSON", func(t *testing.T) {
-		addr := ":5606"
+		addr := ":5706"
 		d := []byte(`{"v":"KERI10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY},"s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-AABAAMiMnE1gmjqoEuDmhbU7aqYBUqKCqAmrHPQB-tPUKSbH_IUXsbglEQ6TGlQT1k7G4VlnKoczYBUd7CPJuo5TnDg`)
 
-		target, err := NewStreamInbound(addr)
+		write := startServer(t, addr)
+		target, err := NewStreamOutbound(addr, 5*time.Second)
 		assert.NoError(t, err)
 
 		_, err = target.Start()
 		assert.NoError(t, err)
 
-		sendMsg(t, addr, d)
+		write(d)
 	})
 	t.Run("bad signature", func(t *testing.T) {
-		addr := ":5607"
+		addr := ":5707"
 		d := []byte(`{"v":"KERI10JSON0000e6_","i":"ENqFtH6_cfDg8riLZ-GDvDaCKVn6clOJa7ZXXVXSWpRY","s":"0","t":"icp","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU","wt":"0","w":[],"c":[]}-XYZBAA`)
 
-		target, err := NewStreamInbound(addr)
+		write := startServer(t, addr)
+		target, err := NewStreamOutbound(addr, 5*time.Second)
 		assert.NoError(t, err)
 
 		_, err = target.Start()
 		assert.NoError(t, err)
 
-		sendMsg(t, addr, d)
+		write(d)
 	})
 }
 
-func sendMsg(t *testing.T, addr string, msgs ...[]byte) {
-	client, err := net.Dial("tcp", addr)
-	assert.NoError(t, err)
+type msgWriter func(msg []byte)
 
-	for _, msg := range msgs {
-		_, err = client.Write(msg)
-		assert.NoError(t, err)
+func startServer(t *testing.T, addr string) msgWriter {
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+
+	ch := make(chan []byte, 2)
+
+	go func() {
+		c, err := ln.Accept()
+		require.NoError(t, err)
+
+		for msg := range ch {
+			_, err = c.Write(msg)
+			assert.NoError(t, err)
+		}
+
+		c.Close()
+	}()
+
+	return func(msg []byte) {
+		ch <- msg
 	}
 
-	err = client.Close()
-	assert.NoError(t, err)
 }

--- a/pkg/io/transport.go
+++ b/pkg/io/transport.go
@@ -4,11 +4,16 @@ import (
 	"github.com/decentralized-identity/kerigo/pkg/event"
 )
 
-type InboundTransport interface {
-	// Start starts the inbound transport.  It returns a channel of event.Messages or an error
-	Start() (<-chan *event.Message, error)
+type Conn interface {
+	Msgs() chan *event.Message
+	Write(msg *event.Message) error
+}
 
-	// Write writes the serialized bytes of the message
+type Transport interface {
+	// Start starts the inbound transport.  It returns a channel of event.Messages or an error
+	Start() (<-chan Conn, error)
+
+	// Write writes to all connections current active for the transport
 	Write(msg *event.Message) error
 
 	// Stop halts the inbound transport

--- a/pkg/keri/keri.go
+++ b/pkg/keri/keri.go
@@ -1,0 +1,213 @@
+package keri
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/pkg/errors"
+
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+	"github.com/decentralized-identity/kerigo/pkg/event"
+	"github.com/decentralized-identity/kerigo/pkg/io"
+	"github.com/decentralized-identity/kerigo/pkg/keymanager"
+)
+
+type Option func(*Keri) error
+
+type Keri struct {
+	pre    string
+	kms    *keymanager.KeyManager
+	reg    *Registry
+	direct []*directConn
+}
+
+type directConn struct {
+	in io.InboundTransport
+}
+
+func New(kms *keymanager.KeyManager, opts ...Option) (*Keri, error) {
+	k := &Keri{
+		kms: kms,
+	}
+
+	reg, err := NewRegistry()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create Keri registry")
+	}
+
+	k.reg = reg
+
+	for _, o := range opts {
+		err := o(k)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	icp, err := event.Incept(kms.PublicKey(), kms.Next())
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create my own inception event")
+	}
+
+	k.pre = icp.Prefix
+
+	sig, err := k.sign(icp)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to sign my inception event")
+	}
+
+	msg := &event.Message{
+		Event:      icp,
+		Signatures: []derivation.Derivation{*sig},
+	}
+
+	err = k.reg.ProcessMessage(msg, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to process my own inception event")
+	}
+
+	return k, nil
+}
+
+func (r *Keri) Prefix() string {
+	return r.pre
+}
+
+func (r *Keri) Sign(data []byte) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *Keri) Rotate() (*event.Event, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *Keri) Interaction(payload []byte) (*event.Event, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *Keri) HandleInboundDirect(in io.InboundTransport) error {
+	ch, err := in.Start()
+	if err != nil {
+		return errors.Wrap(err, "unable to start Keri transport")
+	}
+
+	rcpts, err := r.reg.Process(ch)
+	if err != nil {
+		return errors.Wrap(err, "unable to start process loop for direct connection")
+	}
+
+	go r.generateReceipts(rcpts, in)
+
+	conn := &directConn{
+		in: in,
+	}
+
+	r.direct = append(r.direct, conn)
+	return nil
+}
+
+func (r *Keri) generateReceipts(rcpts <-chan *event.Event, in io.InboundTransport) {
+	for evt := range rcpts {
+		kel, err := r.reg.KEL(r.pre)
+		if err != nil {
+			log.Println("unexpected error getting current KEL", err)
+			continue
+		}
+
+		if evt.ILK() == event.ICP {
+
+			err := r.sendOwnInception(in)
+			if err != nil {
+				log.Println("Unable to send ICP to outbound", err)
+				continue
+			}
+		}
+
+		latestEst := kel.CurrentEstablishment()
+		rec, err := event.TransferableReceipt(evt, latestEst, derivation.Blake3256)
+		if err != nil {
+			log.Println("unable to generate receipt:", err)
+			continue
+		}
+
+		sig, err := derivation.New(derivation.WithCode(derivation.Ed25519Attached), derivation.WithSigner(r.kms.Signer()))
+		if err != nil {
+			log.Println("unexpected error getting new derivation", err)
+			continue
+		}
+
+		//Sign the receipted event, not the receipt
+		evtData, err := json.Marshal(evt)
+		if err != nil {
+			log.Println("unexpected error marshalling receipted event", err)
+			continue
+		}
+
+		_, err = sig.Derive(evtData)
+		if err != nil {
+			log.Println("unable to derive signature", err)
+			continue
+		}
+
+		msg := &event.Message{
+			Event:      rec,
+			Signatures: []derivation.Derivation{*sig},
+		}
+
+		err = in.Write(msg)
+		if err != nil {
+			log.Println("unable to write receipt data", err)
+		}
+	}
+
+}
+
+func (r *Keri) Close() {
+	for _, conn := range r.direct {
+		conn.in.Stop()
+	}
+}
+
+func (r *Keri) sendOwnInception(in io.InboundTransport) error {
+	kel, err := r.reg.KEL(r.pre)
+	if err != nil {
+		return errors.Wrap(err, "unexpected error getting current KEL")
+	}
+
+	icp := kel.Inception()
+	sig, err := r.sign(icp)
+	if err != nil {
+		return err
+	}
+
+	msg := &event.Message{
+		Event:      icp,
+		Signatures: []derivation.Derivation{*sig},
+	}
+
+	err = in.Write(msg)
+	if err != nil {
+		return errors.Wrap(err, "unable to write inception event")
+	}
+
+	return nil
+}
+
+func (r *Keri) sign(evt *event.Event) (*derivation.Derivation, error) {
+	sig, err := derivation.New(derivation.WithCode(derivation.Ed25519Attached), derivation.WithSigner(r.kms.Signer()))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create signer derivation")
+	}
+
+	evtData, err := json.Marshal(evt)
+	if err != nil {
+		return nil, errors.Wrap(err, "unexpected error marshaling event")
+	}
+
+	_, err = sig.Derive(evtData)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to sign event")
+	}
+
+	return sig, nil
+}

--- a/pkg/keri/keri_test.go
+++ b/pkg/keri/keri_test.go
@@ -1,0 +1,99 @@
+package keri
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/google/tink/go/aead"
+	"github.com/google/tink/go/keyset"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/decentralized-identity/kerigo/pkg/db/mem"
+	"github.com/decentralized-identity/kerigo/pkg/io/stream"
+	"github.com/decentralized-identity/kerigo/pkg/keymanager"
+)
+
+func TestInception(t *testing.T) {
+	secrets := []string{"ADW3o9m3udwEf0aoOdZLLJdf1aylokP0lwwI_M2J9h0s", "AagumsL8FeGES7tYcnr_5oN6qcwJzZfLKxoniKUpG4qc"}
+	kms := getKMS(t, secrets)
+
+	k, err := New(kms)
+	assert.NoError(t, err)
+
+	icp, err := k.Inception()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "Eh0fefvTQ55Jwps4dVnIekf7mZgWoU8bCUsDsKeGiEgU", icp.Event.Prefix)
+	assert.Equal(t, "D69EflciVP9zgsihNU14Dbm2bPXoNGxKHK_BBVFMQ-YU", icp.Event.Keys[0])
+	assert.Equal(t, "E2N7cav-AXF8R86YPUWqo8oGu2YcdyFz_w6lTiNmmOY4", icp.Event.Next)
+	assert.Equal(t, "Eh0fefvTQ55Jwps4dVnIekf7mZgWoU8bCUsDsKeGiEgU", k.Prefix())
+}
+
+func TestSign(t *testing.T) {
+	secrets := []string{"ADW3o9m3udwEf0aoOdZLLJdf1aylokP0lwwI_M2J9h0s", "AagumsL8FeGES7tYcnr_5oN6qcwJzZfLKxoniKUpG4qc"}
+	kms := getKMS(t, secrets)
+
+	k, err := New(kms)
+	assert.NoError(t, err)
+
+	sig, err := k.Sign([]byte("this is test data"))
+	assert.NoError(t, err)
+	assert.Equal(t, "huHZ3nrg6FjhF4eKG4SoachALGHN5B0/dqM9Xchf6DMLA17sIjGBOTz9E4l34o/LqqeAbXPR+x7Tz1vWKM9IDw==", base64.StdEncoding.EncodeToString(sig))
+}
+
+func TestDirectConnection(t *testing.T) {
+	addr := ":5803"
+
+	eveSecrets := []string{"ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc", "A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q"}
+	eveKms := getKMS(t, eveSecrets)
+	in, err := stream.NewStreamInbound(addr)
+	assert.NoError(t, err)
+
+	eve, err := New(eveKms)
+	assert.NoError(t, err)
+	go func() {
+		err = eve.HandleDirect(in)
+		assert.NoError(t, err)
+	}()
+
+	bobSecrets := []string{"ADW3o9m3udwEf0aoOdZLLJdf1aylokP0lwwI_M2J9h0s", "AagumsL8FeGES7tYcnr_5oN6qcwJzZfLKxoniKUpG4qc"}
+	bobKms := getKMS(t, bobSecrets)
+	out, err := stream.NewStreamOutbound(addr, 3*time.Second)
+	assert.NoError(t, err)
+
+	bob, err := New(bobKms)
+	assert.NoError(t, err)
+
+	conns, err := out.Start()
+	assert.NoError(t, err)
+
+	icp, err := bob.Inception()
+	assert.NoError(t, err)
+
+	err = out.Write(icp)
+	assert.NoError(t, err)
+
+	conn := <-conns
+	msg := <-conn.Msgs()
+
+	assert.Equal(t, "EH7Oq9oxCgYa-nnNLvwhp9sFZpALILlRYyB-6n4WDi7w", msg.Event.Prefix)
+	assert.Equal(t, "EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU", msg.Event.Next)
+
+	eve.Close()
+}
+
+//TODO: move this into a test package to avoid duplication
+func getKMS(t *testing.T, secrets []string) *keymanager.KeyManager {
+
+	kh, err := keyset.NewHandle(aead.AES256GCMKeyTemplate())
+	assert.NoError(t, err)
+
+	a, err := aead.New(kh)
+	assert.NoError(t, err)
+
+	km, err := keymanager.NewKeyManager(a, mem.NewMemDB(), keymanager.WithSecrets(secrets))
+	assert.NoError(t, err)
+
+	return km
+}

--- a/pkg/keri/registry.go
+++ b/pkg/keri/registry.go
@@ -1,0 +1,118 @@
+package keri
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/decentralized-identity/kerigo/pkg/db"
+	"github.com/decentralized-identity/kerigo/pkg/event"
+	klog "github.com/decentralized-identity/kerigo/pkg/log"
+)
+
+type Registry struct {
+	kels  map[string]*klog.Log
+	store db.DB
+}
+
+func NewRegistry(d db.DB) (*Registry, error) {
+	r := &Registry{
+		store: d,
+		kels:  map[string]*klog.Log{},
+	}
+
+	return r, nil
+}
+
+func (r *Registry) KEL(pre string) (*klog.Log, error) {
+	kel, ok := r.kels[pre]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+
+	return kel, nil
+}
+
+// Process takes a channel of messages for this registry to process and returns a channel
+// of messages that need to be receipted
+func (r *Registry) Process(msgs <-chan *event.Message) (<-chan *event.Event, error) {
+
+	rcpts := make(chan *event.Event)
+
+	go func() {
+		for msg := range msgs {
+			err := r.ProcessMessage(msg, rcpts)
+			if err != nil {
+				log.Printf("registry error processing message: (%+v)\n", err)
+			}
+		}
+	}()
+
+	return rcpts, nil
+}
+
+func (r *Registry) ProcessMessage(msg *event.Message, rcpts chan *event.Event) error {
+
+	fmt.Println(msg.Event.EventType, msg.Event.Prefix)
+
+	switch msg.Event.ILK() {
+	case event.ICP, event.ROT, event.DIP, event.IXN, event.DRT:
+		err := r.processEvent(msg)
+		if err != nil {
+			return err
+		}
+
+		if rcpts != nil {
+			rcpts <- msg.Event
+		}
+	case event.VRC:
+		return r.processReceipt(msg)
+	case event.RCT:
+		log.Println(event.RCT, "not supported, yet")
+	}
+
+	return nil
+}
+
+func (r *Registry) processEvent(msg *event.Message) error {
+
+	evt := msg.Event
+	ilk := evt.ILK()
+
+	kel, ok := r.kels[evt.Prefix]
+	if !ok {
+		if ilk != event.ICP && ilk != event.DIP {
+			//TODO: Handle out-of-order events
+			return errors.New("out of order events not currently handled")
+		}
+
+		kel = klog.New()
+		r.kels[evt.Prefix] = kel
+	} else {
+		if ilk == event.ICP || ilk == event.DIP {
+			//TODO: Handle duplicitious events
+			return errors.New("duplicitious events not currently handled")
+		}
+	}
+
+	err := kel.Verify(msg)
+	if err != nil {
+		return fmt.Errorf("unable to verify message: (%v)", err)
+	}
+
+	err = kel.Apply(msg)
+	if err != nil {
+		return fmt.Errorf("unable to apply message: (%v)", err)
+	}
+
+	return nil
+}
+
+func (r *Registry) processReceipt(msg *event.Message) error {
+	err := r.store.AddVRC("what is the key", msg.Event)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/log/main_test.go
+++ b/pkg/log/main_test.go
@@ -510,3 +510,34 @@ func newKeys(num int) ([]*basicKeys, error) {
 
 	return keys, nil
 }
+
+func TestReceipts(t *testing.T) {
+	k, err := newKeys(2)
+	assert.NoError(t, err)
+
+	icp, err := event.NewInceptionEvent(event.WithDefaultVersion(event.JSON), event.WithKeys(k[0].pre))
+	assert.NoError(t, err)
+	est, err := event.NewInceptionEvent(event.WithDefaultVersion(event.JSON), event.WithKeys(k[1].pre))
+	assert.NoError(t, err)
+
+	vrc, err := event.TransferableReceipt(icp, est, derivation.Blake3256)
+	assert.NoError(t, err)
+
+	msg := &event.Message{
+		Event: icp,
+	}
+
+	kel := New()
+	err = kel.Apply(msg)
+
+	assert.NoError(t, err)
+
+	msg = &event.Message{
+		Event: vrc,
+	}
+	err = kel.ApplyReceipt(msg)
+	assert.NoError(t, err)
+
+	rcpts := kel.ReceiptsForEvent(icp)
+	assert.Len(t, rcpts, 1)
+}

--- a/pkg/log/receipts.go
+++ b/pkg/log/receipts.go
@@ -1,0 +1,13 @@
+package log
+
+import (
+	"github.com/decentralized-identity/kerigo/pkg/event"
+)
+
+type Register map[string][]*event.Message
+
+func (r Register) Add(vrc *event.Message) error {
+	dig := vrc.Event.Digest
+	r[dig] = append(r[dig], vrc)
+	return nil
+}

--- a/pkg/log/receipts_test.go
+++ b/pkg/log/receipts_test.go
@@ -1,0 +1,38 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/decentralized-identity/kerigo/pkg/derivation"
+	"github.com/decentralized-identity/kerigo/pkg/event"
+)
+
+func TestAddReceipt(t *testing.T) {
+	k, err := newKeys(2)
+	assert.NoError(t, err)
+
+	icp, err := event.NewInceptionEvent(event.WithDefaultVersion(event.JSON), event.WithKeys(k[0].pre))
+	assert.NoError(t, err)
+	est, err := event.NewInceptionEvent(event.WithDefaultVersion(event.JSON), event.WithKeys(k[1].pre))
+	assert.NoError(t, err)
+
+	vrc, err := event.TransferableReceipt(icp, est, derivation.Blake3256)
+	assert.NoError(t, err)
+
+	msg := &event.Message{
+		Event: vrc,
+	}
+
+	r := Register{}
+	err = r.Add(msg)
+	assert.NoError(t, err)
+
+	dig := vrc.Digest
+
+	rcpt := r[dig]
+	assert.Len(t, rcpt, 1)
+	assert.Equal(t, msg, rcpt[0])
+
+}


### PR DESCRIPTION
This PR contains:

 - `keri` package as the public API
 - Updating to the io package to unify to one `Transport` interface with in/out implementations.
 - Naive handling of receipts to allow demos to complete
 - Full Eve demo app
 - Partial Bob demo app