### PR TITLE
updated KMS to require db.DB

### DIFF
--- a/pkg/db/badger/badger_test.go
+++ b/pkg/db/badger/badger_test.go
@@ -663,7 +663,7 @@ func TestSignatures(t *testing.T) {
 	dig, err := icp.GetDigest()
 	assert.NoError(t, err)
 
-	kms := testkms.GetKMS(t, secrets)
+	kms := testkms.GetKMS(t, secrets, db)
 
 	ser, err := icp.Serialize()
 	assert.NoError(t, err)
@@ -737,7 +737,7 @@ func TestMessage(t *testing.T) {
 	dig, err := icp.GetDigest()
 	assert.NoError(t, err)
 
-	kms := testkms.GetKMS(t, secrets)
+	kms := testkms.GetKMS(t, secrets, db)
 
 	ser, err := icp.Serialize()
 	assert.NoError(t, err)

--- a/pkg/direct/direct_test.go
+++ b/pkg/direct/direct_test.go
@@ -21,7 +21,7 @@ func TestDial(t *testing.T) {
 		"A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E",
 	}
 
-	bobKMS := kms.GetKMS(t, bobSecrets)
+	bobKMS := kms.GetKMS(t, bobSecrets, mem.New())
 
 	bobID, err := keri.New(bobKMS, mem.New())
 	assert.NoError(t, err)
@@ -39,7 +39,7 @@ func TestSingleMessage(t *testing.T) {
 	}
 	addr := ":5901"
 
-	eveKMS := kms.GetKMS(t, eveSecrets)
+	eveKMS := kms.GetKMS(t, eveSecrets, mem.New())
 
 	eveID, err := keri.New(eveKMS, mem.New())
 	assert.NoError(t, err)
@@ -61,7 +61,7 @@ func TestSingleMessage(t *testing.T) {
 		"AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc",
 	}
 
-	bobKMS := kms.GetKMS(t, bobSecrets)
+	bobKMS := kms.GetKMS(t, bobSecrets, mem.New())
 
 	bobID, err := keri.New(bobKMS, mem.New())
 	assert.NoError(t, err)
@@ -99,7 +99,7 @@ func TestWithNotify(t *testing.T) {
 	}
 	addr := ":5902"
 
-	eveKMS := kms.GetKMS(t, eveSecrets)
+	eveKMS := kms.GetKMS(t, eveSecrets, mem.New())
 
 	eveID, err := keri.New(eveKMS, mem.New())
 	assert.NoError(t, err)
@@ -121,7 +121,7 @@ func TestWithNotify(t *testing.T) {
 		"AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc",
 	}
 
-	bobKMS := kms.GetKMS(t, bobSecrets)
+	bobKMS := kms.GetKMS(t, bobSecrets, mem.New())
 
 	bobID, err := keri.New(bobKMS, mem.New())
 	assert.NoError(t, err)

--- a/pkg/direct/server.go
+++ b/pkg/direct/server.go
@@ -170,7 +170,7 @@ func (r *Server) removeConnection(conn *conn) {
 }
 
 func defaultKMS() *keymanager.KeyManager {
-	kms, _ := keymanager.NewKeyManager()
+	kms, _ := keymanager.NewKeyManager(keymanager.WithStore(mem.New()))
 	return kms
 }
 

--- a/pkg/keri/keri_test.go
+++ b/pkg/keri/keri_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestInception(t *testing.T) {
 	secrets := []string{"ADW3o9m3udwEf0aoOdZLLJdf1aylokP0lwwI_M2J9h0s", "AagumsL8FeGES7tYcnr_5oN6qcwJzZfLKxoniKUpG4qc"}
-	kms := testkms.GetKMS(t, secrets)
+	kms := testkms.GetKMS(t, secrets, mem.New())
 
 	k, err := New(kms, mem.New())
 	assert.NoError(t, err)
@@ -30,7 +30,7 @@ func TestInception(t *testing.T) {
 
 func TestSign(t *testing.T) {
 	secrets := []string{"ADW3o9m3udwEf0aoOdZLLJdf1aylokP0lwwI_M2J9h0s", "AagumsL8FeGES7tYcnr_5oN6qcwJzZfLKxoniKUpG4qc"}
-	kms := testkms.GetKMS(t, secrets)
+	kms := testkms.GetKMS(t, secrets, mem.New())
 
 	k, err := New(kms, mem.New())
 	assert.NoError(t, err)
@@ -47,11 +47,11 @@ func TestDirectMode(t *testing.T) {
 
 	t.Run("no wait", func(t *testing.T) {
 
-		eveKms := testkms.GetKMS(t, eveSecrets)
+		eveKms := testkms.GetKMS(t, eveSecrets, mem.New())
 		eve, err := New(eveKms, mem.New())
 		assert.NoError(t, err)
 
-		bobKms := testkms.GetKMS(t, bobSecrets)
+		bobKms := testkms.GetKMS(t, bobSecrets, mem.New())
 		bob, err := New(bobKms, mem.New())
 		assert.NoError(t, err)
 
@@ -89,11 +89,11 @@ func TestDirectMode(t *testing.T) {
 
 	t.Run("wait", func(t *testing.T) {
 
-		eveKms := testkms.GetKMS(t, eveSecrets)
+		eveKms := testkms.GetKMS(t, eveSecrets, mem.New())
 		eve, err := New(eveKms, mem.New())
 		assert.NoError(t, err)
 
-		bobKms := testkms.GetKMS(t, bobSecrets)
+		bobKms := testkms.GetKMS(t, bobSecrets, mem.New())
 		bob, err := New(bobKms, mem.New())
 		assert.NoError(t, err)
 
@@ -141,7 +141,7 @@ func TestDirectMode(t *testing.T) {
 func TestInteractionEvent(t *testing.T) {
 	expectedBytes := `{"v":"KERI10JSON000098_","i":"Eh0fefvTQ55Jwps4dVnIekf7mZgWoU8bCUsDsKeGiEgU","s":"1","t":"ixn","p":"EUO96wFpqn7NQgDqRybT1ADVgaony353BSIOkJwdBFSE","a":[]}-AABAAvle4YOvsulhpBC3PbZRe3hNF2JaVDUMlzLaiIk61Puaizy2jCYuoM3ycgM-v0VqKGDrSNbBFXxyVSYSesMhgDw`
 	secrets := []string{"ADW3o9m3udwEf0aoOdZLLJdf1aylokP0lwwI_M2J9h0s", "AagumsL8FeGES7tYcnr_5oN6qcwJzZfLKxoniKUpG4qc"}
-	kms := testkms.GetKMS(t, secrets)
+	kms := testkms.GetKMS(t, secrets, mem.New())
 
 	k, err := New(kms, mem.New())
 	assert.NoError(t, err)
@@ -162,11 +162,11 @@ func TestFindConnection(t *testing.T) {
 
 	t.Run("no wait", func(t *testing.T) {
 
-		eveKms := testkms.GetKMS(t, eveSecrets)
+		eveKms := testkms.GetKMS(t, eveSecrets, mem.New())
 		eve, err := New(eveKms, mem.New())
 		assert.NoError(t, err)
 
-		bobKms := testkms.GetKMS(t, bobSecrets)
+		bobKms := testkms.GetKMS(t, bobSecrets, mem.New())
 		bob, err := New(bobKms, mem.New())
 		assert.NoError(t, err)
 
@@ -183,7 +183,7 @@ func TestFindConnection(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		kms := testkms.GetKMS(t, secrets)
+		kms := testkms.GetKMS(t, secrets, mem.New())
 
 		k, err := New(kms, mem.New())
 		assert.NoError(t, err)

--- a/pkg/keymanager/keymanager.go
+++ b/pkg/keymanager/keymanager.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/decentralized-identity/kerigo/pkg/db"
-	"github.com/decentralized-identity/kerigo/pkg/db/mem"
 	"github.com/decentralized-identity/kerigo/pkg/derivation"
 )
 
@@ -37,7 +36,6 @@ func NewKeyManager(opts ...Option) (*KeyManager, error) {
 
 	km := &KeyManager{
 		secrets: []string{},
-		store:   mem.New(),
 		kw:      &dummyAEAD{},
 	}
 
@@ -46,6 +44,10 @@ func NewKeyManager(opts ...Option) (*KeyManager, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if km.store == nil {
+		return nil, errors.New("must provide db")
 	}
 
 	km.enveloper = aead.NewKMSEnvelopeAEAD2(aead.AES256GCMKeyTemplate(), km.kw)

--- a/pkg/keymanager/keymanager_test.go
+++ b/pkg/keymanager/keymanager_test.go
@@ -32,6 +32,7 @@ func keyMgr(t *testing.T, opts ...Option) *KeyManager {
 	assert.NoError(t, err)
 
 	opts = append(opts, WithAEAD(a))
+	opts = append(opts, WithStore(mem.New()))
 	km, err := NewKeyManager(opts...)
 	assert.NoError(t, err)
 	return km

--- a/pkg/log/main_test.go
+++ b/pkg/log/main_test.go
@@ -125,7 +125,7 @@ func TestVerifyAndApply(t *testing.T) {
 	assert := assert.New(t)
 	db := mem.New()
 
-	kms := testkms.GetKMS(t, secrets)
+	kms := testkms.GetKMS(t, secrets, mem.New())
 	thresh, _ := event.NewSigThreshold(1)
 	icp := test.InceptionFromSecrets(t, []string{secrets[0]}, []string{secrets[1]}, *thresh, *thresh)
 
@@ -291,14 +291,14 @@ func TestMultiSigApply(t *testing.T) {
 
 	db := mem.New()
 
-	kms1 := testkms.GetKMS(t, secrets[:2])
+	kms1 := testkms.GetKMS(t, secrets[:2], mem.New())
 	sigDer1, err := derivation.New(derivation.WithCode(derivation.Ed25519Attached), derivation.WithSigner(kms1.Signer()))
 	assert.Nil(err)
-	kms2 := testkms.GetKMS(t, secrets[3:5])
+	kms2 := testkms.GetKMS(t, secrets[3:5], mem.New())
 	sigDer2, err := derivation.New(derivation.WithCode(derivation.Ed25519Attached), derivation.WithSigner(kms2.Signer()))
 	sigDer2.KeyIndex = 1
 	assert.Nil(err)
-	kms3 := testkms.GetKMS(t, secrets[6:])
+	kms3 := testkms.GetKMS(t, secrets[6:], mem.New())
 	sigDer3, err := derivation.New(derivation.WithCode(derivation.Ed25519Attached), derivation.WithSigner(kms3.Signer()))
 	sigDer3.KeyIndex = 2
 	assert.Nil(err)
@@ -531,7 +531,7 @@ func TestReceipts(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	kms1 := testkms.GetKMS(t, secrets[:2])
+	kms1 := testkms.GetKMS(t, secrets[:2], mem.New())
 	siger, err := derivation.New(derivation.WithCode(derivation.Ed25519Attached), derivation.WithSigner(kms1.Signer()))
 
 	ser, err := vrc.Serialize()

--- a/pkg/test/kms/kms.go
+++ b/pkg/test/kms/kms.go
@@ -7,10 +7,11 @@ import (
 	"github.com/google/tink/go/keyset"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/decentralized-identity/kerigo/pkg/db"
 	"github.com/decentralized-identity/kerigo/pkg/keymanager"
 )
 
-func GetKMS(t *testing.T, secrets []string) *keymanager.KeyManager {
+func GetKMS(t *testing.T, secrets []string, store db.DB) *keymanager.KeyManager {
 
 	kh, err := keyset.NewHandle(aead.AES256GCMKeyTemplate())
 	assert.NoError(t, err)
@@ -18,7 +19,7 @@ func GetKMS(t *testing.T, secrets []string) *keymanager.KeyManager {
 	a, err := aead.New(kh)
 	assert.NoError(t, err)
 
-	km, err := keymanager.NewKeyManager(keymanager.WithAEAD(a), keymanager.WithSecrets(secrets))
+	km, err := keymanager.NewKeyManager(keymanager.WithAEAD(a), keymanager.WithSecrets(secrets), keymanager.WithStore(store))
 	assert.NoError(t, err)
 
 	return km


### PR DESCRIPTION
Removes import cycle when using KMS in db/mem tests